### PR TITLE
Roll back the type annotations for union() and intersect()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ docs/build
 spark-warehouse
 dist/
 build/
+output.json

--- a/docs/source/advanced_linting_support.ipynb
+++ b/docs/source/advanced_linting_support.ipynb
@@ -79,8 +79,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Other functions for which this is currently implemented include:\n",
+    "The functions for which this is currently implemented include:\n",
     "\n",
+    "* `filter()`\n",
     "* `distinct()`\n",
     "* `orderBy()`\n",
     "\n",
@@ -98,7 +99,7 @@
     "df_a = create_partially_filled_dataset(spark, A, {A.a: [\"a\", \"b\", \"c\"]})\n",
     "df_b = create_partially_filled_dataset(spark, A, {A.a: [\"d\", \"e\", \"f\"]})\n",
     "\n",
-    "res = df_a.union(df_b)"
+    "res = df_a.unionByName(df_b)"
    ]
   },
   {
@@ -106,10 +107,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Other functions in this category include:\n",
+    "The functions in this category include:\n",
     "\n",
     "* `unionByName()`\n",
-    "* `intersect()`\n",
     "* `join(..., how=\"semi\")`\n",
     "\n",
     "## Transformations\n",

--- a/tests/_core/test_dataset.py
+++ b/tests/_core/test_dataset.py
@@ -81,7 +81,5 @@ def test_inherrited_functions_with_other_dataset(spark: SparkSession):
     df_a = create_empty_dataset(spark, A)
     df_b = create_empty_dataset(spark, A)
 
-    df_a.intersect(df_b)
     df_a.join(df_b, A.a.str)
-    df_a.union(df_b)
     df_a.unionByName(df_b)

--- a/typedspark/_core/dataset.py
+++ b/typedspark/_core/dataset.py
@@ -97,20 +97,6 @@ class DataSet(DataFrame, Generic[T]):
         return DataSet[self._schema_annotations](super().filter(condition))  # type: ignore
 
     @overload
-    def intersect(self, other: "DataSet[T]") -> "DataSet[T]":
-        ...  # pragma: no cover
-
-    @overload
-    def intersect(self, other: DataFrame) -> DataFrame:
-        ...  # pragma: no cover
-
-    def intersect(self, other: DataFrame) -> DataFrame:  # pylint: disable=C0116
-        res = super().intersect(other)
-        if isinstance(other, DataSet) and other._schema_annotations == self._schema_annotations:
-            return DataSet[self._schema_annotations](res)  # type: ignore
-        return res  # pragma: no cover
-
-    @overload
     def join(
         self,
         other: DataFrame,
@@ -162,20 +148,6 @@ class DataSet(DataFrame, Generic[T]):
         self, func: Callable[..., "DataFrame"], *args: Any, **kwargs: Any
     ) -> "DataFrame":
         return super().transform(func, *args, **kwargs)
-
-    @overload
-    def union(self, other: "DataSet[T]") -> "DataSet[T]":
-        ...  # pragma: no cover
-
-    @overload
-    def union(self, other: DataFrame) -> DataFrame:
-        ...  # pragma: no cover
-
-    def union(self, other: DataFrame) -> DataFrame:  # pylint: disable=C0116
-        res = super().union(other)
-        if isinstance(other, DataSet) and other._schema_annotations == self._schema_annotations:
-            return DataSet[self._schema_annotations](res)  # type: ignore
-        return res  # pragma: no cover
 
     @overload
     def unionByName(  # noqa: N802  # pylint: disable=C0116, C0103


### PR DESCRIPTION
The functions `DataFrame.union()` and `DataFrame.intersect()` do not take column names into consideration, but are instead based on column number. Since the columns in a `DataSet` can be of any ordering, this means that we cannot guarantee that `DataSet[T].union(df: DataSet[T]) -> DataSet[T]`. For this purpose, please use `unionByName()`.