### PR TITLE
Update documentation

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -10,4 +10,5 @@ Advanced
    subclassing_schemas
    column_ambiguity
    advanced_linting_support
-   databricks
+   generating_schemas
+   autocomplete_in_databricks

--- a/docs/source/advanced_linting_support.ipynb
+++ b/docs/source/advanced_linting_support.ipynb
@@ -3,7 +3,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "b83251c2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003042,
+     "end_time": "2023-04-13T15:19:55.870019",
+     "exception": false,
+     "start_time": "2023-04-13T15:19:55.866977",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Advanced type-checking using linters\n",
     "## Functions that do not affect the schema\n",
@@ -13,8 +23,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": null,
+   "id": "bdf75d36",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:19:55.875316Z",
+     "iopub.status.busy": "2023-04-13T15:19:55.875080Z",
+     "iopub.status.idle": "2023-04-13T15:20:02.373741Z",
+     "shell.execute_reply": "2023-04-13T15:20:02.373259Z"
+    },
+    "papermill": {
+     "duration": 6.502752,
+     "end_time": "2023-04-13T15:20:02.375098",
+     "exception": false,
+     "start_time": "2023-04-13T15:19:55.872346",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
@@ -24,8 +50,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": 2,
+   "id": "c84b26e9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:02.378689Z",
+     "iopub.status.busy": "2023-04-13T15:20:02.378496Z",
+     "iopub.status.idle": "2023-04-13T15:20:03.639073Z",
+     "shell.execute_reply": "2023-04-13T15:20:03.638703Z"
+    },
+    "papermill": {
+     "duration": 1.263607,
+     "end_time": "2023-04-13T15:20:03.640269",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:02.376662",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from typedspark import Column, Schema, DataSet, create_partially_filled_dataset\n",
@@ -41,7 +83,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "01675118",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001204,
+     "end_time": "2023-04-13T15:20:03.643083",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:03.641879",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "In the above example, `filter()` will not actually make any changes to the schema, hence we have implemented the return type of `DataSet.filter()` to be a `DataSet` of the same `Schema` that you started with. In other words, a linter will see that `res` is of the type `DataSet[A]`.\n",
     "\n",
@@ -50,8 +102,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
+   "execution_count": 3,
+   "id": "b0fe9344",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:03.646707Z",
+     "iopub.status.busy": "2023-04-13T15:20:03.646527Z",
+     "iopub.status.idle": "2023-04-13T15:20:03.649004Z",
+     "shell.execute_reply": "2023-04-13T15:20:03.648529Z"
+    },
+    "papermill": {
+     "duration": 0.005816,
+     "end_time": "2023-04-13T15:20:03.650274",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:03.644458",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def foo(df: DataSet[A]) -> DataSet[A]:\n",
@@ -61,7 +129,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "4ed27a7d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00118,
+     "end_time": "2023-04-13T15:20:03.652922",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:03.651742",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "The functions for which this is currently implemented include:\n",
     "\n",
@@ -76,8 +154,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
+   "execution_count": 4,
+   "id": "3abfb0d8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:03.656004Z",
+     "iopub.status.busy": "2023-04-13T15:20:03.655859Z",
+     "iopub.status.idle": "2023-04-13T15:20:03.707767Z",
+     "shell.execute_reply": "2023-04-13T15:20:03.707399Z"
+    },
+    "papermill": {
+     "duration": 0.054827,
+     "end_time": "2023-04-13T15:20:03.708927",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:03.654100",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "df_a = create_partially_filled_dataset(spark, A, {A.a: [\"a\", \"b\", \"c\"]})\n",
@@ -89,7 +183,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "dfa33e61",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00108,
+     "end_time": "2023-04-13T15:20:03.711359",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:03.710279",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "The functions in this category include:\n",
     "\n",
@@ -103,8 +207,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
+   "execution_count": 5,
+   "id": "5b0df362",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:03.714917Z",
+     "iopub.status.busy": "2023-04-13T15:20:03.714796Z",
+     "iopub.status.idle": "2023-04-13T15:20:03.747490Z",
+     "shell.execute_reply": "2023-04-13T15:20:03.747198Z"
+    },
+    "papermill": {
+     "duration": 0.03619,
+     "end_time": "2023-04-13T15:20:03.748613",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:03.712423",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from typedspark import transform_to_schema\n",
@@ -131,7 +251,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "4221be22",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00112,
+     "end_time": "2023-04-13T15:20:03.751179",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:03.750059",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Did we miss anything?\n",
     "\n",
@@ -140,7 +270,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "d21ad841",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001314,
+     "end_time": "2023-04-13T15:20:03.753581",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:03.752267",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": []
   }
  ],
@@ -162,8 +302,19 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.16"
   },
-  "orig_nbformat": 4
+  "papermill": {
+   "default_parameters": {},
+   "duration": 9.404374,
+   "end_time": "2023-04-13T15:20:04.375908",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "docs/source/advanced_linting_support.ipynb",
+   "output_path": "docs/source/advanced_linting_support.ipynb",
+   "parameters": {},
+   "start_time": "2023-04-13T15:19:54.971534",
+   "version": "2.4.0"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/docs/source/advanced_linting_support.ipynb
+++ b/docs/source/advanced_linting_support.ipynb
@@ -18,7 +18,8 @@
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
-    "spark = SparkSession.Builder().getOrCreate()"
+    "spark = SparkSession.Builder().getOrCreate()\n",
+    "spark.sparkContext.setLogLevel(\"ERROR\")"
    ]
   },
   {

--- a/docs/source/autocomplete_in_databricks.ipynb
+++ b/docs/source/autocomplete_in_databricks.ipynb
@@ -5,8 +5,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Using typedspark in Databricks notebooks\n",
-    "You can dynamically load a `DataSet` and its corresponding `Schema` from a table in Databricks. To illustrate this, let us first make a temporary table that we can load later."
+    "# Dynamically generate Schemas from existing tables\n",
+    "You can dynamically load a `DataSet` and its corresponding `Schema` from an existing table. To illustrate this, let us first make a temporary table that we can load later."
    ]
   },
   {
@@ -18,7 +18,8 @@
     "import warnings\n",
     "from pyspark.sql import SparkSession \n",
     "warnings.filterwarnings('ignore')\n",
-    "spark = SparkSession.Builder().getOrCreate()"
+    "spark = SparkSession.Builder().getOrCreate()\n",
+    "spark.sparkContext.setLogLevel(\"ERROR\")"
    ]
   },
   {
@@ -66,51 +67,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can now use `df` and `Person` just like you would in your IDE. One of the advantages is that this provides auto-complete on column names. No more looking at `df.columns` every minute to remember the column names!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+----+---+\n",
-      "|name|age|\n",
-      "+----+---+\n",
-      "|John| 30|\n",
-      "|Jane| 40|\n",
-      "+----+---+\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
-     ]
-    }
-   ],
-   "source": [
-    "(\n",
-    "    df\n",
-    "    .filter(Person.age > 25)\n",
-    "    .show()\n",
-    ")"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Of note, `load_table()` automatically runs `register_schema_to_dataset()` on the resulting `DataSet` and `Schema`, hence resolving potential column disambiguities.\n",
-    "\n",
-    "A second situation in which `load_table()` is helpful is when you want to add schemas to existing tables. Simply run:"
+    "From here, it's trivial to generate the `Schema` for this table."
    ]
   },
   {
@@ -176,6 +133,56 @@
    ],
    "source": [
     "Person.print_schema(schema_name=\"Person\", include_documentation=True)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can now use `df` and `Person` just like you would in your IDE. On Databricks, this also comes with an additional advantage: auto-complete on column names. No more looking at `df.columns` every minute to remember the column names!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+----+---+\n",
+      "|name|age|\n",
+      "+----+---+\n",
+      "|John| 30|\n",
+      "|Jane| 40|\n",
+      "+----+---+\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    }
+   ],
+   "source": [
+    "(\n",
+    "    df\n",
+    "    .filter(Person.age > 25)\n",
+    "    .show()\n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Of note, `load_table()` automatically runs `register_schema_to_dataset()` on the resulting `DataSet` and `Schema`, hence resolving potential column disambiguities."
    ]
   },
   {

--- a/docs/source/autocomplete_in_databricks.ipynb
+++ b/docs/source/autocomplete_in_databricks.ipynb
@@ -3,16 +3,44 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "c3322756",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005963,
+     "end_time": "2023-04-13T15:20:05.605215",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:05.599252",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "# Dynamically generate Schemas from existing tables\n",
-    "You can dynamically load a `DataSet` and its corresponding `Schema` from an existing table. To illustrate this, let us first make a temporary table that we can load later."
+    "# Autocomplete in Databricks notebooks\n",
+    "When we use `load_table()` on Databricks, it also offers autocomplete on the column names. No more looking at `df.columns` every minute to remember the column names!\n",
+    "\n",
+    "To illustrate this, let us first generate a table that we'll write to the table `person_table`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": null,
+   "id": "87752202",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:05.612451Z",
+     "iopub.status.busy": "2023-04-13T15:20:05.612125Z",
+     "iopub.status.idle": "2023-04-13T15:20:12.112115Z",
+     "shell.execute_reply": "2023-04-13T15:20:12.111760Z"
+    },
+    "papermill": {
+     "duration": 6.504683,
+     "end_time": "2023-04-13T15:20:12.113325",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:05.608642",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -24,8 +52,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": 2,
+   "id": "6c1e5acc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:12.116656Z",
+     "iopub.status.busy": "2023-04-13T15:20:12.116401Z",
+     "iopub.status.idle": "2023-04-13T15:20:13.504748Z",
+     "shell.execute_reply": "2023-04-13T15:20:13.504416Z"
+    },
+    "papermill": {
+     "duration": 1.391122,
+     "end_time": "2023-04-13T15:20:13.505881",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:12.114759",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -46,15 +90,41 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "4bd96763",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001021,
+     "end_time": "2023-04-13T15:20:13.508357",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:13.507336",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "We can now load these data using `load_table()`. Note that the `Schema` is inferred: it doesn't need to have been serialized using `typedspark`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
+   "execution_count": 3,
+   "id": "3003dea9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:13.511122Z",
+     "iopub.status.busy": "2023-04-13T15:20:13.510977Z",
+     "iopub.status.idle": "2023-04-13T15:20:13.537299Z",
+     "shell.execute_reply": "2023-04-13T15:20:13.536994Z"
+    },
+    "papermill": {
+     "duration": 0.029109,
+     "end_time": "2023-04-13T15:20:13.538427",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:13.509318",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from typedspark import load_table\n",
@@ -65,88 +135,41 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "65c183c1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.000989,
+     "end_time": "2023-04-13T15:20:13.540683",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:13.539694",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "From here, it's trivial to generate the `Schema` for this table."
+    "You can now use `df` and `Person` just like you would in your IDE, including autocomplete!"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\n",
-       "from pyspark.sql.types import LongType, StringType\n",
-       "\n",
-       "from typedspark import Column, Schema\n",
-       "\n",
-       "\n",
-       "class DynamicallyLoadedSchema(Schema):\n",
-       "    name: Column[StringType]\n",
-       "    age: Column[LongType]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "Person"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To also generate documentation, run:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "from typing import Annotated\n",
-      "\n",
-      "from pyspark.sql.types import LongType, StringType\n",
-      "\n",
-      "from typedspark import Column, ColumnMeta, Schema\n",
-      "\n",
-      "\n",
-      "class Person(Schema):\n",
-      "    \"\"\"Add documentation here.\"\"\"\n",
-      "\n",
-      "    name: Annotated[Column[StringType], ColumnMeta(comment=\"\")]\n",
-      "    age: Annotated[Column[LongType], ColumnMeta(comment=\"\")]\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "Person.print_schema(schema_name=\"Person\", include_documentation=True)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can now use `df` and `Person` just like you would in your IDE. On Databricks, this also comes with an additional advantage: auto-complete on column names. No more looking at `df.columns` every minute to remember the column names!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
+   "execution_count": 4,
+   "id": "f38e0e20",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:13.543766Z",
+     "iopub.status.busy": "2023-04-13T15:20:13.543611Z",
+     "iopub.status.idle": "2023-04-13T15:20:14.339209Z",
+     "shell.execute_reply": "2023-04-13T15:20:14.338848Z"
+    },
+    "papermill": {
+     "duration": 0.798418,
+     "end_time": "2023-04-13T15:20:14.340278",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:13.541860",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -159,13 +182,6 @@
       "|Jane| 40|\n",
       "+----+---+\n",
       "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
      ]
     }
    ],
@@ -180,14 +196,36 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "08f247d1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001065,
+     "end_time": "2023-04-13T15:20:14.342835",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:14.341770",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "Of note, `load_table()` automatically runs `register_schema_to_dataset()` on the resulting `DataSet` and `Schema`, hence resolving potential column disambiguities."
+    "Of note, `load_table()` automatically runs `register_schema_to_dataset()` on the resulting `DataSet` and `Schema`, hence resolving potential column disambiguities.\n",
+    "\n",
+    "The above has been tested on Databricks, but may also work in other types of notebooks. Best way to find out is to try!"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "534ee9d9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00113,
+     "end_time": "2023-04-13T15:20:14.345003",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:14.343873",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": []
   }
  ],
@@ -209,8 +247,19 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.16"
   },
-  "orig_nbformat": 4
+  "papermill": {
+   "default_parameters": {},
+   "duration": 10.376197,
+   "end_time": "2023-04-13T15:20:15.068092",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "docs/source/autocomplete_in_databricks.ipynb",
+   "output_path": "docs/source/autocomplete_in_databricks.ipynb",
+   "parameters": {},
+   "start_time": "2023-04-13T15:20:04.691895",
+   "version": "2.4.0"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/docs/source/column_ambiguity.ipynb
+++ b/docs/source/column_ambiguity.ipynb
@@ -3,7 +3,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "a836183d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002461,
+     "end_time": "2023-04-13T15:29:51.388542",
+     "exception": false,
+     "start_time": "2023-04-13T15:29:51.386081",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Dealing with column ambiguity\n",
     "\n",
@@ -12,25 +22,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": null,
+   "id": "ee6a97e4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:29:51.393406Z",
+     "iopub.status.busy": "2023-04-13T15:29:51.393024Z",
+     "iopub.status.idle": "2023-04-13T15:29:58.000980Z",
+     "shell.execute_reply": "2023-04-13T15:29:58.000609Z"
+    },
+    "papermill": {
+     "duration": 6.612131,
+     "end_time": "2023-04-13T15:29:58.002168",
+     "exception": false,
+     "start_time": "2023-04-13T15:29:51.390037",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
-    "spark = SparkSession.Builder().getOrCreate()\n",
+    "spark = SparkSession.Builder().config(\"spark.ui.showConsoleProgress\", \"false\").getOrCreate()\n",
     "spark.sparkContext.setLogLevel(\"ERROR\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": 2,
+   "id": "6206d284",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:29:58.005521Z",
+     "iopub.status.busy": "2023-04-13T15:29:58.005181Z",
+     "iopub.status.idle": "2023-04-13T15:29:59.344053Z",
+     "shell.execute_reply": "2023-04-13T15:29:59.343570Z"
+    },
+    "papermill": {
+     "duration": 1.34187,
+     "end_time": "2023-04-13T15:29:59.345429",
+     "exception": false,
+     "start_time": "2023-04-13T15:29:58.003559",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "23/04/09 15:30:14 WARN Column: Constructing trivially true equals predicate, ''id = 'id'. Perhaps you need to use aliases.\n",
       "Reference 'id' is ambiguous, could be: id, id.\n"
      ]
     }
@@ -61,23 +102,42 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "09be224a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001152,
+     "end_time": "2023-04-13T15:29:59.348134",
+     "exception": false,
+     "start_time": "2023-04-13T15:29:59.346982",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "The above resulted in a `AnalysisException`, because Spark can't figure out whether `id` belongs to `df_a` or `df_b`. To deal with this, you need to register your `Schema` to the `DataSet`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[Stage 0:>                                                        (0 + 10) / 10]\r"
-     ]
+   "execution_count": 3,
+   "id": "459a5e06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:29:59.351141Z",
+     "iopub.status.busy": "2023-04-13T15:29:59.350996Z",
+     "iopub.status.idle": "2023-04-13T15:30:00.778375Z",
+     "shell.execute_reply": "2023-04-13T15:30:00.777982Z"
     },
+    "papermill": {
+     "duration": 1.430365,
+     "end_time": "2023-04-13T15:30:00.779747",
+     "exception": false,
+     "start_time": "2023-04-13T15:29:59.349382",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
@@ -90,13 +150,6 @@
       "|  3|null|null|  3|  null|\n",
       "+---+----+----+---+------+\n",
       "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
      ]
     }
    ],
@@ -115,15 +168,41 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "8359bd08",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001269,
+     "end_time": "2023-04-13T15:30:00.782528",
+     "exception": false,
+     "start_time": "2023-04-13T15:30:00.781259",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "It is often a good idea to drop the ambiguous column, for example:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
+   "execution_count": 4,
+   "id": "e0f1a644",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:30:00.785593Z",
+     "iopub.status.busy": "2023-04-13T15:30:00.785414Z",
+     "iopub.status.idle": "2023-04-13T15:30:01.045593Z",
+     "shell.execute_reply": "2023-04-13T15:30:01.045096Z"
+    },
+    "papermill": {
+     "duration": 0.263291,
+     "end_time": "2023-04-13T15:30:01.046975",
+     "exception": false,
+     "start_time": "2023-04-13T15:30:00.783684",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -159,7 +238,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "5b08a13f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001377,
+     "end_time": "2023-04-13T15:30:01.049894",
+     "exception": false,
+     "start_time": "2023-04-13T15:30:01.048517",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": []
   }
  ],
@@ -181,8 +270,19 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.16"
   },
-  "orig_nbformat": 4
+  "papermill": {
+   "default_parameters": {},
+   "duration": 11.181015,
+   "end_time": "2023-04-13T15:30:01.673306",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "docs/source/column_ambiguity.ipynb",
+   "output_path": "docs/source/column_ambiguity.ipynb",
+   "parameters": {},
+   "start_time": "2023-04-13T15:29:50.492291",
+   "version": "2.4.0"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/docs/source/column_ambiguity.ipynb
+++ b/docs/source/column_ambiguity.ipynb
@@ -17,7 +17,8 @@
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
-    "spark = SparkSession.Builder().getOrCreate()"
+    "spark = SparkSession.Builder().getOrCreate()\n",
+    "spark.sparkContext.setLogLevel(\"ERROR\")"
    ]
   },
   {
@@ -29,7 +30,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "23/04/09 15:18:19 WARN Column: Constructing trivially true equals predicate, ''id = 'id'. Perhaps you need to use aliases.\n",
+      "23/04/09 15:30:14 WARN Column: Constructing trivially true equals predicate, ''id = 'id'. Perhaps you need to use aliases.\n",
       "Reference 'id' is ambiguous, could be: id, id.\n"
      ]
     }

--- a/docs/source/column_ambiguity.ipynb
+++ b/docs/source/column_ambiguity.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,14 +22,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "23/03/23 11:47:15 WARN Column: Constructing trivially true equals predicate, ''id = 'id'. Perhaps you need to use aliases.\n",
+      "23/04/09 15:18:19 WARN Column: Constructing trivially true equals predicate, ''id = 'id'. Perhaps you need to use aliases.\n",
       "Reference 'id' is ambiguous, could be: id, id.\n"
      ]
     }
@@ -67,9 +67,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Stage 0:>                                                        (0 + 10) / 10]\r"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -82,6 +89,13 @@
       "|  3|null|null|  3|  null|\n",
       "+---+----+----+---+------+\n",
       "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
      ]
     }
    ],
@@ -107,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -143,10 +157,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": []
   }
  ],

--- a/docs/source/complex_datatypes.ipynb
+++ b/docs/source/complex_datatypes.ipynb
@@ -3,7 +3,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "72077ffb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005304,
+     "end_time": "2023-04-13T15:20:27.462073",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:27.456769",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Complex datatypes\n",
     "Spark contains several data types that are slightly more complex. \n",
@@ -15,7 +25,23 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "id": "934c2a2d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:27.468561Z",
+     "iopub.status.busy": "2023-04-13T15:20:27.468221Z",
+     "iopub.status.idle": "2023-04-13T15:20:27.568829Z",
+     "shell.execute_reply": "2023-04-13T15:20:27.567844Z"
+    },
+    "papermill": {
+     "duration": 0.107456,
+     "end_time": "2023-04-13T15:20:27.572443",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:27.464987",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from pyspark.sql.types import StringType\n",
@@ -34,7 +60,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "271da325",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001043,
+     "end_time": "2023-04-13T15:20:27.576508",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:27.575465",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## DecimalType\n",
     "\n",
@@ -44,7 +80,23 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "id": "3ccb56ff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:27.584820Z",
+     "iopub.status.busy": "2023-04-13T15:20:27.584303Z",
+     "iopub.status.idle": "2023-04-13T15:20:27.600903Z",
+     "shell.execute_reply": "2023-04-13T15:20:27.596097Z"
+    },
+    "papermill": {
+     "duration": 0.027714,
+     "end_time": "2023-04-13T15:20:27.606781",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:27.579067",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from typing import Literal\n",
@@ -57,7 +109,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "8a2232b3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001083,
+     "end_time": "2023-04-13T15:20:27.612574",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:27.611491",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Did we miss a data type?\n",
     "\n",
@@ -66,7 +128,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "33d83e5f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002191,
+     "end_time": "2023-04-13T15:20:27.617196",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:27.615005",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": []
   }
  ],
@@ -88,8 +160,19 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.16"
   },
-  "orig_nbformat": 4
+  "papermill": {
+   "default_parameters": {},
+   "duration": 1.178237,
+   "end_time": "2023-04-13T15:20:27.739104",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "docs/source/complex_datatypes.ipynb",
+   "output_path": "docs/source/complex_datatypes.ipynb",
+   "parameters": {},
+   "start_time": "2023-04-13T15:20:26.560867",
+   "version": "2.4.0"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/docs/source/create_empty_datasets.ipynb
+++ b/docs/source/create_empty_datasets.ipynb
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -151,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -200,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,6 +231,11 @@
     "\n",
     "    assert_df_equality(observed, expected, ignore_row_order=True, ignore_nullable=True)\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/source/create_empty_datasets.ipynb
+++ b/docs/source/create_empty_datasets.ipynb
@@ -16,7 +16,8 @@
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
-    "spark = SparkSession.Builder().getOrCreate()"
+    "spark = SparkSession.Builder().getOrCreate()\n",
+    "spark.sparkContext.setLogLevel(\"ERROR\")"
    ]
   },
   {
@@ -36,13 +37,6 @@
       "|null|null|null|\n",
       "+----+----+----+\n",
       "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
      ]
     }
    ],

--- a/docs/source/create_empty_datasets.ipynb
+++ b/docs/source/create_empty_datasets.ipynb
@@ -3,7 +3,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "f25abb69",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007407,
+     "end_time": "2023-04-13T15:20:28.948134",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:28.940727",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Easier unit testing through the creation of empty DataSets from schemas\n",
     "We provide helper functions to generate (partially) empty DataSets from existing schemas. This can be helpful in certain situations, such as unit testing."
@@ -11,8 +21,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": null,
+   "id": "25b679fc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:28.955463Z",
+     "iopub.status.busy": "2023-04-13T15:20:28.955157Z",
+     "iopub.status.idle": "2023-04-13T15:20:35.581396Z",
+     "shell.execute_reply": "2023-04-13T15:20:35.581031Z"
+    },
+    "papermill": {
+     "duration": 6.631171,
+     "end_time": "2023-04-13T15:20:35.582625",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:28.951454",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
@@ -22,8 +48,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": 2,
+   "id": "7a2690c7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:35.586072Z",
+     "iopub.status.busy": "2023-04-13T15:20:35.585852Z",
+     "iopub.status.idle": "2023-04-13T15:20:37.682067Z",
+     "shell.execute_reply": "2023-04-13T15:20:37.681747Z"
+    },
+    "papermill": {
+     "duration": 2.099043,
+     "end_time": "2023-04-13T15:20:37.683127",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:35.584084",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -55,8 +97,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
+   "execution_count": 3,
+   "id": "d5ce76e1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:37.686360Z",
+     "iopub.status.busy": "2023-04-13T15:20:37.686213Z",
+     "iopub.status.idle": "2023-04-13T15:20:37.799144Z",
+     "shell.execute_reply": "2023-04-13T15:20:37.798715Z"
+    },
+    "papermill": {
+     "duration": 0.115959,
+     "end_time": "2023-04-13T15:20:37.800521",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:37.684562",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -88,7 +146,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "74e41042",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001248,
+     "end_time": "2023-04-13T15:20:37.803390",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:37.802142",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Complex datatypes\n",
     "\n",
@@ -97,8 +165,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
+   "execution_count": 4,
+   "id": "3578c0e5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:37.806747Z",
+     "iopub.status.busy": "2023-04-13T15:20:37.806562Z",
+     "iopub.status.idle": "2023-04-13T15:20:38.058925Z",
+     "shell.execute_reply": "2023-04-13T15:20:38.058441Z"
+    },
+    "papermill": {
+     "duration": 0.25546,
+     "end_time": "2023-04-13T15:20:38.060055",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:37.804595",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -145,8 +229,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
+   "execution_count": 5,
+   "id": "e2d3b302",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:38.063850Z",
+     "iopub.status.busy": "2023-04-13T15:20:38.063690Z",
+     "iopub.status.idle": "2023-04-13T15:20:38.194434Z",
+     "shell.execute_reply": "2023-04-13T15:20:38.194037Z"
+    },
+    "papermill": {
+     "duration": 0.133748,
+     "end_time": "2023-04-13T15:20:38.195474",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:38.061726",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -185,7 +285,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "43fb6f66",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001213,
+     "end_time": "2023-04-13T15:20:38.198265",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:38.197052",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Example unit test\n",
     "\n",
@@ -194,8 +304,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
+   "execution_count": 6,
+   "id": "f80ddebf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:38.202940Z",
+     "iopub.status.busy": "2023-04-13T15:20:38.202620Z",
+     "iopub.status.idle": "2023-04-13T15:20:38.209893Z",
+     "shell.execute_reply": "2023-04-13T15:20:38.209522Z"
+    },
+    "papermill": {
+     "duration": 0.01172,
+     "end_time": "2023-04-13T15:20:38.211163",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:38.199443",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
@@ -228,7 +354,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "571cf714",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001234,
+     "end_time": "2023-04-13T15:20:38.214075",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:38.212841",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": []
   }
  ],
@@ -250,8 +386,19 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.16"
   },
-  "orig_nbformat": 4
+  "papermill": {
+   "default_parameters": {},
+   "duration": 10.884884,
+   "end_time": "2023-04-13T15:20:38.937714",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "docs/source/create_empty_datasets.ipynb",
+   "output_path": "docs/source/create_empty_datasets.ipynb",
+   "parameters": {},
+   "start_time": "2023-04-13T15:20:28.052830",
+   "version": "2.4.0"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/docs/source/databricks.ipynb
+++ b/docs/source/databricks.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -85,6 +85,13 @@
       "|Jane| 40|\n",
       "+----+---+\n",
       "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
      ]
     }
    ],
@@ -108,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -125,7 +132,7 @@
        "    age: Column[LongType]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -144,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {

--- a/docs/source/documentation.ipynb
+++ b/docs/source/documentation.ipynb
@@ -3,7 +3,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "4b8cb87a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.014318,
+     "end_time": "2023-04-13T15:20:40.167416",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:40.153098",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Documentation of tables\n",
     "You can add documentation to schemas as follows:"
@@ -12,7 +22,23 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "id": "d2e1e850",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:40.174594Z",
+     "iopub.status.busy": "2023-04-13T15:20:40.174194Z",
+     "iopub.status.idle": "2023-04-13T15:20:40.272254Z",
+     "shell.execute_reply": "2023-04-13T15:20:40.271327Z"
+    },
+    "papermill": {
+     "duration": 0.107311,
+     "end_time": "2023-04-13T15:20:40.276814",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:40.169503",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from typing import Annotated\n",
@@ -42,7 +68,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "302ad462",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002055,
+     "end_time": "2023-04-13T15:20:40.281557",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:40.279502",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "If you use Databricks and Delta Live Tables, you can make the documentation appear in the Databricks UI by using the following Delta Live Table definition:\n",
     "\n",
@@ -55,7 +91,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "17c2b1a6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001448,
+     "end_time": "2023-04-13T15:20:40.284162",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:40.282714",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": []
   }
  ],
@@ -77,8 +123,19 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.16"
   },
-  "orig_nbformat": 4
+  "papermill": {
+   "default_parameters": {},
+   "duration": 1.153841,
+   "end_time": "2023-04-13T15:20:40.408310",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "docs/source/documentation.ipynb",
+   "output_path": "docs/source/documentation.ipynb",
+   "parameters": {},
+   "start_time": "2023-04-13T15:20:39.254469",
+   "version": "2.4.0"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/docs/source/generating_schemas.ipynb
+++ b/docs/source/generating_schemas.ipynb
@@ -3,7 +3,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "a006aaea",
+   "metadata": {
+    "papermill": {
+     "duration": 0.014696,
+     "end_time": "2023-04-13T15:20:41.640535",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:41.625839",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Dynamically generate Schemas from existing tables\n",
     "You can dynamically load a `DataSet` and its corresponding `Schema` from an existing table. To illustrate this, let us first make a temporary table that we can load later."
@@ -11,8 +21,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": null,
+   "id": "5442cec0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:41.658754Z",
+     "iopub.status.busy": "2023-04-13T15:20:41.658234Z",
+     "iopub.status.idle": "2023-04-13T15:20:48.316928Z",
+     "shell.execute_reply": "2023-04-13T15:20:48.316589Z"
+    },
+    "papermill": {
+     "duration": 6.666446,
+     "end_time": "2023-04-13T15:20:48.318150",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:41.651704",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -24,8 +50,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": 2,
+   "id": "0df943fb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:48.322094Z",
+     "iopub.status.busy": "2023-04-13T15:20:48.321878Z",
+     "iopub.status.idle": "2023-04-13T15:20:49.751762Z",
+     "shell.execute_reply": "2023-04-13T15:20:49.751453Z"
+    },
+    "papermill": {
+     "duration": 1.433118,
+     "end_time": "2023-04-13T15:20:49.752974",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:48.319856",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -46,15 +88,41 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "10524400",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001263,
+     "end_time": "2023-04-13T15:20:49.755847",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:49.754584",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "We can now load these data using `load_table()`. Note that the `Schema` is inferred: it doesn't need to have been serialized using `typedspark`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
+   "execution_count": 3,
+   "id": "b6c659c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:49.759282Z",
+     "iopub.status.busy": "2023-04-13T15:20:49.759142Z",
+     "iopub.status.idle": "2023-04-13T15:20:49.786301Z",
+     "shell.execute_reply": "2023-04-13T15:20:49.785978Z"
+    },
+    "papermill": {
+     "duration": 0.030522,
+     "end_time": "2023-04-13T15:20:49.787598",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:49.757076",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from typedspark import load_table\n",
@@ -65,15 +133,41 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "51e4792d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001247,
+     "end_time": "2023-04-13T15:20:49.790461",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:49.789214",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "From here, it's trivial to generate the `Schema` for this table."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
+   "execution_count": 4,
+   "id": "defb2a82",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:49.793621Z",
+     "iopub.status.busy": "2023-04-13T15:20:49.793472Z",
+     "iopub.status.idle": "2023-04-13T15:20:49.797196Z",
+     "shell.execute_reply": "2023-04-13T15:20:49.796908Z"
+    },
+    "papermill": {
+     "duration": 0.006438,
+     "end_time": "2023-04-13T15:20:49.798123",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:49.791685",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -89,7 +183,7 @@
        "    age: Column[LongType]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -101,15 +195,41 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "bdaf1423",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001246,
+     "end_time": "2023-04-13T15:20:49.801614",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:49.800368",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "To also generate documentation, run:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
+   "execution_count": 5,
+   "id": "7305a079",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:49.804670Z",
+     "iopub.status.busy": "2023-04-13T15:20:49.804549Z",
+     "iopub.status.idle": "2023-04-13T15:20:49.806487Z",
+     "shell.execute_reply": "2023-04-13T15:20:49.806250Z"
+    },
+    "papermill": {
+     "duration": 0.004531,
+     "end_time": "2023-04-13T15:20:49.807390",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:49.802859",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -138,15 +258,41 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "0f6ef71c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015975,
+     "end_time": "2023-04-13T15:20:49.824716",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:49.808741",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "You can now use `df` and `Person` just like you would in your IDE. On Databricks, this also comes with an additional advantage: auto-complete on column names. No more looking at `df.columns` every minute to remember the column names!"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
+   "execution_count": 6,
+   "id": "9ef250c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:49.828022Z",
+     "iopub.status.busy": "2023-04-13T15:20:49.827873Z",
+     "iopub.status.idle": "2023-04-13T15:20:50.634035Z",
+     "shell.execute_reply": "2023-04-13T15:20:50.633524Z"
+    },
+    "papermill": {
+     "duration": 0.809179,
+     "end_time": "2023-04-13T15:20:50.635214",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:49.826035",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -159,13 +305,6 @@
       "|Jane| 40|\n",
       "+----+---+\n",
       "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
      ]
     }
    ],
@@ -180,14 +319,34 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "15c03521",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001675,
+     "end_time": "2023-04-13T15:20:50.638776",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:50.637101",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Of note, `load_table()` automatically runs `register_schema_to_dataset()` on the resulting `DataSet` and `Schema`, hence resolving potential column disambiguities."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "18ea295c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001702,
+     "end_time": "2023-04-13T15:20:50.642114",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:50.640412",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": []
   }
  ],
@@ -209,8 +368,19 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.16"
   },
-  "orig_nbformat": 4
+  "papermill": {
+   "default_parameters": {},
+   "duration": 10.639983,
+   "end_time": "2023-04-13T15:20:51.368193",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "docs/source/generating_schemas.ipynb",
+   "output_path": "docs/source/generating_schemas.ipynb",
+   "parameters": {},
+   "start_time": "2023-04-13T15:20:40.728210",
+   "version": "2.4.0"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/docs/source/generating_schemas.ipynb
+++ b/docs/source/generating_schemas.ipynb
@@ -1,0 +1,216 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dynamically generate Schemas from existing tables\n",
+    "You can dynamically load a `DataSet` and its corresponding `Schema` from an existing table. To illustrate this, let us first make a temporary table that we can load later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "from pyspark.sql import SparkSession \n",
+    "warnings.filterwarnings('ignore')\n",
+    "spark = SparkSession.Builder().getOrCreate()\n",
+    "spark.sparkContext.setLogLevel(\"ERROR\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "(\n",
+    "    spark.createDataFrame(\n",
+    "        pd.DataFrame(\n",
+    "            dict(\n",
+    "                name=[\"Jack\", \"John\", \"Jane\"],\n",
+    "                age=[20, 30, 40],\n",
+    "            )\n",
+    "        )\n",
+    "    )\n",
+    "    .createOrReplaceTempView(\"person_table\")\n",
+    ")\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now load these data using `load_table()`. Note that the `Schema` is inferred: it doesn't need to have been serialized using `typedspark`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typedspark import load_table\n",
+    "\n",
+    "df, Person = load_table(spark, \"person_table\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From here, it's trivial to generate the `Schema` for this table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "from pyspark.sql.types import LongType, StringType\n",
+       "\n",
+       "from typedspark import Column, Schema\n",
+       "\n",
+       "\n",
+       "class DynamicallyLoadedSchema(Schema):\n",
+       "    name: Column[StringType]\n",
+       "    age: Column[LongType]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Person"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To also generate documentation, run:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "from typing import Annotated\n",
+      "\n",
+      "from pyspark.sql.types import LongType, StringType\n",
+      "\n",
+      "from typedspark import Column, ColumnMeta, Schema\n",
+      "\n",
+      "\n",
+      "class Person(Schema):\n",
+      "    \"\"\"Add documentation here.\"\"\"\n",
+      "\n",
+      "    name: Annotated[Column[StringType], ColumnMeta(comment=\"\")]\n",
+      "    age: Annotated[Column[LongType], ColumnMeta(comment=\"\")]\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "Person.print_schema(schema_name=\"Person\", include_documentation=True)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can now use `df` and `Person` just like you would in your IDE. On Databricks, this also comes with an additional advantage: auto-complete on column names. No more looking at `df.columns` every minute to remember the column names!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+----+---+\n",
+      "|name|age|\n",
+      "+----+---+\n",
+      "|John| 30|\n",
+      "|Jane| 40|\n",
+      "+----+---+\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    }
+   ],
+   "source": [
+    "(\n",
+    "    df\n",
+    "    .filter(Person.age > 25)\n",
+    "    .show()\n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Of note, `load_table()` automatically runs `register_schema_to_dataset()` on the resulting `DataSet` and `Schema`, hence resolving potential column disambiguities."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "typedspark",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/source/schema_attributes.ipynb
+++ b/docs/source/schema_attributes.ipynb
@@ -3,7 +3,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "011002f2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.011159,
+     "end_time": "2023-04-13T15:20:52.644496",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:52.633337",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Auto-complete & easier refactoring using schema attributes \n",
     "Schemas allow us to replaces the numerous strings throughout the code by schema attributes. Consider the following example:"
@@ -12,7 +22,23 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "id": "6379b38b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:52.659586Z",
+     "iopub.status.busy": "2023-04-13T15:20:52.659008Z",
+     "iopub.status.idle": "2023-04-13T15:20:52.751344Z",
+     "shell.execute_reply": "2023-04-13T15:20:52.750466Z"
+    },
+    "papermill": {
+     "duration": 0.099487,
+     "end_time": "2023-04-13T15:20:52.754541",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:52.655054",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from typedspark import Column, DataSet, Schema\n",
@@ -33,7 +59,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "a03a164a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.000965,
+     "end_time": "2023-04-13T15:20:52.758997",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:52.758032",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "We can replace this with:"
    ]
@@ -41,7 +77,23 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "id": "1e6fa606",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:52.771083Z",
+     "iopub.status.busy": "2023-04-13T15:20:52.768668Z",
+     "iopub.status.idle": "2023-04-13T15:20:52.788212Z",
+     "shell.execute_reply": "2023-04-13T15:20:52.785831Z"
+    },
+    "papermill": {
+     "duration": 0.03075,
+     "end_time": "2023-04-13T15:20:52.792218",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:52.761468",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def birthday(df: DataSet[Person]) -> DataSet[Person]:\n",
@@ -53,7 +105,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "4232e8ce",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002675,
+     "end_time": "2023-04-13T15:20:52.797605",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:52.794930",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Which allows:\n",
     "\n",
@@ -70,7 +132,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "4a56cffb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002434,
+     "end_time": "2023-04-13T15:20:52.801130",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:52.798696",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": []
   }
  ],
@@ -92,8 +164,19 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.16"
   },
-  "orig_nbformat": 4
+  "papermill": {
+   "default_parameters": {},
+   "duration": 1.197411,
+   "end_time": "2023-04-13T15:20:52.922519",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "docs/source/schema_attributes.ipynb",
+   "output_path": "docs/source/schema_attributes.ipynb",
+   "parameters": {},
+   "start_time": "2023-04-13T15:20:51.725108",
+   "version": "2.4.0"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/docs/source/structtype_columns.ipynb
+++ b/docs/source/structtype_columns.ipynb
@@ -17,7 +17,8 @@
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
-    "spark = SparkSession.Builder().getOrCreate()"
+    "spark = SparkSession.Builder().getOrCreate()\n",
+    "spark.sparkContext.setLogLevel(\"ERROR\")"
    ]
   },
   {

--- a/docs/source/structtype_columns.ipynb
+++ b/docs/source/structtype_columns.ipynb
@@ -22,16 +22,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[Stage 0:>                                                          (0 + 1) / 1]\r"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -44,13 +37,6 @@
       "|{3, 4}|\n",
       "+------+\n",
       "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
      ]
     }
    ],
@@ -103,14 +89,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "23/03/23 11:00:40 WARN Column: Constructing trivially true equals predicate, ''a = 'a'. Perhaps you need to use aliases.\n",
+      "23/04/09 15:21:17 WARN Column: Constructing trivially true equals predicate, ''a = 'a'. Perhaps you need to use aliases.\n",
       "Cannot convert column into bool: please use '&' for 'and', '|' for 'or', '~' for 'not' when building DataFrame boolean expressions.\n"
      ]
     }
@@ -180,10 +166,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": []
   }
  ],

--- a/docs/source/structtype_columns.ipynb
+++ b/docs/source/structtype_columns.ipynb
@@ -3,7 +3,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "913f374b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006831,
+     "end_time": "2023-04-13T15:20:54.156848",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:54.150017",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Adding StructType columns\n",
     "\n",
@@ -12,8 +22,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": null,
+   "id": "11cb3442",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:20:54.172343Z",
+     "iopub.status.busy": "2023-04-13T15:20:54.171875Z",
+     "iopub.status.idle": "2023-04-13T15:21:00.810349Z",
+     "shell.execute_reply": "2023-04-13T15:21:00.809963Z"
+    },
+    "papermill": {
+     "duration": 6.647458,
+     "end_time": "2023-04-13T15:21:00.811631",
+     "exception": false,
+     "start_time": "2023-04-13T15:20:54.164173",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
@@ -23,8 +49,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": 2,
+   "id": "3e0bac9d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:21:00.814831Z",
+     "iopub.status.busy": "2023-04-13T15:21:00.814641Z",
+     "iopub.status.idle": "2023-04-13T15:21:03.010319Z",
+     "shell.execute_reply": "2023-04-13T15:21:03.009924Z"
+    },
+    "papermill": {
+     "duration": 2.198578,
+     "end_time": "2023-04-13T15:21:03.011595",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:00.813017",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -83,21 +125,46 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "0bcea41d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001034,
+     "end_time": "2023-04-13T15:21:03.014097",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:03.013063",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Just like in `transform_to_schema()`, the `transformations` dictionary in `structtype_column(..., transformations)` requires columns with unique names as keys."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
+   "execution_count": 3,
+   "id": "9c070a24",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:21:03.016955Z",
+     "iopub.status.busy": "2023-04-13T15:21:03.016806Z",
+     "iopub.status.idle": "2023-04-13T15:21:03.041522Z",
+     "shell.execute_reply": "2023-04-13T15:21:03.041165Z"
+    },
+    "papermill": {
+     "duration": 0.027532,
+     "end_time": "2023-04-13T15:21:03.042612",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:03.015080",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "23/04/09 15:21:17 WARN Column: Constructing trivially true equals predicate, ''a = 'a'. Perhaps you need to use aliases.\n",
       "Cannot convert column into bool: please use '&' for 'and', '|' for 'or', '~' for 'not' when building DataFrame boolean expressions.\n"
      ]
     }
@@ -125,15 +192,41 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "10b43a86",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001144,
+     "end_time": "2023-04-13T15:21:03.045047",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:03.043903",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Instead, combine these into a single line:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
+   "execution_count": 4,
+   "id": "b88b95b0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:21:03.048185Z",
+     "iopub.status.busy": "2023-04-13T15:21:03.048013Z",
+     "iopub.status.idle": "2023-04-13T15:21:03.165840Z",
+     "shell.execute_reply": "2023-04-13T15:21:03.165452Z"
+    },
+    "papermill": {
+     "duration": 0.120962,
+     "end_time": "2023-04-13T15:21:03.167082",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:03.046120",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -168,7 +261,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "acee3a29",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001104,
+     "end_time": "2023-04-13T15:21:03.169645",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:03.168541",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": []
   }
  ],
@@ -190,8 +293,19 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.16"
   },
-  "orig_nbformat": 4
+  "papermill": {
+   "default_parameters": {},
+   "duration": 10.546448,
+   "end_time": "2023-04-13T15:21:03.792724",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "docs/source/structtype_columns.ipynb",
+   "output_path": "docs/source/structtype_columns.ipynb",
+   "parameters": {},
+   "start_time": "2023-04-13T15:20:53.246276",
+   "version": "2.4.0"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/docs/source/subclassing_schemas.ipynb
+++ b/docs/source/subclassing_schemas.ipynb
@@ -3,7 +3,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "76ffac97",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004295,
+     "end_time": "2023-04-13T15:21:05.037814",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:05.033519",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Subclassing schemas\n",
     "Subclassing schemas is a useful pattern for pipelines where every next function adds a few columns."
@@ -12,7 +22,23 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "id": "7725965f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:21:05.051022Z",
+     "iopub.status.busy": "2023-04-13T15:21:05.050617Z",
+     "iopub.status.idle": "2023-04-13T15:21:05.138677Z",
+     "shell.execute_reply": "2023-04-13T15:21:05.137584Z"
+    },
+    "papermill": {
+     "duration": 0.097968,
+     "end_time": "2023-04-13T15:21:05.142328",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:05.044360",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from typedspark import Column, Schema, DataSet\n",
@@ -35,7 +61,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "cc265385",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002689,
+     "end_time": "2023-04-13T15:21:05.148148",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:05.145459",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Similarly, you can use this pattern when merging (or joining or concatenating) two datasets together."
    ]
@@ -43,7 +79,23 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "id": "c0d6b6a6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:21:05.155515Z",
+     "iopub.status.busy": "2023-04-13T15:21:05.154984Z",
+     "iopub.status.idle": "2023-04-13T15:21:05.184765Z",
+     "shell.execute_reply": "2023-04-13T15:21:05.180674Z"
+    },
+    "papermill": {
+     "duration": 0.038231,
+     "end_time": "2023-04-13T15:21:05.189010",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:05.150779",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "class PersonA(Schema):\n",
@@ -65,7 +117,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "b24f0e09",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002207,
+     "end_time": "2023-04-13T15:21:05.193973",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:05.191766",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": []
   }
  ],
@@ -87,8 +149,19 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.16"
   },
-  "orig_nbformat": 4
+  "papermill": {
+   "default_parameters": {},
+   "duration": 1.18375,
+   "end_time": "2023-04-13T15:21:05.317674",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "docs/source/subclassing_schemas.ipynb",
+   "output_path": "docs/source/subclassing_schemas.ipynb",
+   "parameters": {},
+   "start_time": "2023-04-13T15:21:04.133924",
+   "version": "2.4.0"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/docs/source/transforming_datasets.ipynb
+++ b/docs/source/transforming_datasets.ipynb
@@ -3,7 +3,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "ab6cce16",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002946,
+     "end_time": "2023-04-13T15:03:24.221011",
+     "exception": false,
+     "start_time": "2023-04-13T15:03:24.218065",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Transforming a DataSet to another schema\n",
     "\n",
@@ -13,7 +23,23 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "id": "44b1c3bb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:03:24.226100Z",
+     "iopub.status.busy": "2023-04-13T15:03:24.225881Z",
+     "iopub.status.idle": "2023-04-13T15:03:24.306167Z",
+     "shell.execute_reply": "2023-04-13T15:03:24.304172Z"
+    },
+    "papermill": {
+     "duration": 0.08633,
+     "end_time": "2023-04-13T15:03:24.309507",
+     "exception": false,
+     "start_time": "2023-04-13T15:03:24.223177",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from pyspark.sql.types import IntegerType\n",
@@ -53,7 +79,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "2ba1ded0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006545,
+     "end_time": "2023-04-13T15:03:24.319882",
+     "exception": false,
+     "start_time": "2023-04-13T15:03:24.313337",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "We can make that quite a bit more condensed:"
    ]
@@ -61,7 +97,23 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "id": "a08d2a1f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:03:24.327772Z",
+     "iopub.status.busy": "2023-04-13T15:03:24.327433Z",
+     "iopub.status.idle": "2023-04-13T15:03:24.357490Z",
+     "shell.execute_reply": "2023-04-13T15:03:24.343256Z"
+    },
+    "papermill": {
+     "duration": 0.042434,
+     "end_time": "2023-04-13T15:03:24.364466",
+     "exception": false,
+     "start_time": "2023-04-13T15:03:24.322032",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from typedspark import transform_to_schema\n",
@@ -82,7 +134,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "bb3fb301",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003426,
+     "end_time": "2023-04-13T15:03:24.372125",
+     "exception": false,
+     "start_time": "2023-04-13T15:03:24.368699",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "This function can also be used to just select the subset of columns used in the schema, simply omit the third argument."
    ]
@@ -90,7 +152,23 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "id": "1e13a30f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:03:24.378031Z",
+     "iopub.status.busy": "2023-04-13T15:03:24.377625Z",
+     "iopub.status.idle": "2023-04-13T15:03:24.384186Z",
+     "shell.execute_reply": "2023-04-13T15:03:24.383359Z"
+    },
+    "papermill": {
+     "duration": 0.012828,
+     "end_time": "2023-04-13T15:03:24.387328",
+     "exception": false,
+     "start_time": "2023-04-13T15:03:24.374500",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "class A(Schema):\n",
@@ -111,48 +189,73 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "98d00a0f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001276,
+     "end_time": "2023-04-13T15:03:24.390610",
+     "exception": false,
+     "start_time": "2023-04-13T15:03:24.389334",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "The `transformations` dictionary in `transform_to_schema(..., transformations)` requires columns with unique names as keys. The following pattern will throw an exception."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Setting default log level to \"WARN\".\n",
-      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
-     ]
+   "execution_count": null,
+   "id": "916f8122",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:03:24.400119Z",
+     "iopub.status.busy": "2023-04-13T15:03:24.399579Z",
+     "iopub.status.idle": "2023-04-13T15:03:30.930802Z",
+     "shell.execute_reply": "2023-04-13T15:03:30.930452Z"
     },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "23/04/09 15:21:53 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n",
-      "23/04/09 15:21:54 WARN Utils: Service 'SparkUI' could not bind on port 4040. Attempting port 4041.\n"
-     ]
-    }
-   ],
+    "papermill": {
+     "duration": 6.537529,
+     "end_time": "2023-04-13T15:03:30.931968",
+     "exception": false,
+     "start_time": "2023-04-13T15:03:24.394439",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
-    "spark = SparkSession.Builder().getOrCreate()"
+    "spark = SparkSession.Builder().getOrCreate()\n",
+    "spark.sparkContext.setLogLevel(\"ERROR\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "id": "756995ae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:03:30.936255Z",
+     "iopub.status.busy": "2023-04-13T15:03:30.936065Z",
+     "iopub.status.idle": "2023-04-13T15:03:32.218543Z",
+     "shell.execute_reply": "2023-04-13T15:03:32.218208Z"
+    },
+    "papermill": {
+     "duration": 1.285295,
+     "end_time": "2023-04-13T15:03:32.219533",
+     "exception": false,
+     "start_time": "2023-04-13T15:03:30.934238",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "23/04/09 15:21:55 WARN Column: Constructing trivially true equals predicate, ''a = 'a'. Perhaps you need to use aliases.\n",
       "Cannot convert column into bool: please use '&' for 'and', '|' for 'or', '~' for 'not' when building DataFrame boolean expressions.\n"
      ]
     }
@@ -178,7 +281,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "67b9285c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001233,
+     "end_time": "2023-04-13T15:03:32.222317",
+     "exception": false,
+     "start_time": "2023-04-13T15:03:32.221084",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Instead, use one line per column"
    ]
@@ -186,15 +299,24 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
-     ]
+   "id": "46c8833f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:03:32.225322Z",
+     "iopub.status.busy": "2023-04-13T15:03:32.225186Z",
+     "iopub.status.idle": "2023-04-13T15:03:33.163806Z",
+     "shell.execute_reply": "2023-04-13T15:03:33.163513Z"
     },
+    "papermill": {
+     "duration": 0.941458,
+     "end_time": "2023-04-13T15:03:33.164943",
+     "exception": false,
+     "start_time": "2023-04-13T15:03:32.223485",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
@@ -222,7 +344,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "6546f023",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001306,
+     "end_time": "2023-04-13T15:03:33.181123",
+     "exception": false,
+     "start_time": "2023-04-13T15:03:33.179817",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": []
   }
  ],
@@ -244,8 +376,19 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.16"
   },
-  "orig_nbformat": 4
+  "papermill": {
+   "default_parameters": {},
+   "duration": 10.474924,
+   "end_time": "2023-04-13T15:03:33.803982",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "docs/source/transforming_datasets.ipynb",
+   "output_path": "docs/source/transforming_datasets.ipynb",
+   "parameters": {},
+   "start_time": "2023-04-13T15:03:23.329058",
+   "version": "2.4.0"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/docs/source/transforming_datasets.ipynb
+++ b/docs/source/transforming_datasets.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,9 +118,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Setting default log level to \"WARN\".\n",
+      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "23/04/09 15:21:53 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n",
+      "23/04/09 15:21:54 WARN Utils: Service 'SparkUI' could not bind on port 4040. Attempting port 4041.\n"
+     ]
+    }
+   ],
    "source": [
     "from pyspark.sql import SparkSession\n",
     "spark = SparkSession.Builder().getOrCreate()"
@@ -128,14 +145,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "23/03/23 10:51:45 WARN Column: Constructing trivially true equals predicate, ''a = 'a'. Perhaps you need to use aliases.\n",
+      "23/04/09 15:21:55 WARN Column: Constructing trivially true equals predicate, ''a = 'a'. Perhaps you need to use aliases.\n",
       "Cannot convert column into bool: please use '&' for 'and', '|' for 'or', '~' for 'not' when building DataFrame boolean expressions.\n"
      ]
     }
@@ -168,9 +185,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",

--- a/docs/source/transforming_datasets.ipynb
+++ b/docs/source/transforming_datasets.ipynb
@@ -6,10 +6,10 @@
    "id": "ab6cce16",
    "metadata": {
     "papermill": {
-     "duration": 0.002946,
-     "end_time": "2023-04-13T15:03:24.221011",
+     "duration": 0.010896,
+     "end_time": "2023-04-13T15:21:06.538150",
      "exception": false,
-     "start_time": "2023-04-13T15:03:24.218065",
+     "start_time": "2023-04-13T15:21:06.527254",
      "status": "completed"
     },
     "tags": []
@@ -26,16 +26,16 @@
    "id": "44b1c3bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-04-13T15:03:24.226100Z",
-     "iopub.status.busy": "2023-04-13T15:03:24.225881Z",
-     "iopub.status.idle": "2023-04-13T15:03:24.306167Z",
-     "shell.execute_reply": "2023-04-13T15:03:24.304172Z"
+     "iopub.execute_input": "2023-04-13T15:21:06.553578Z",
+     "iopub.status.busy": "2023-04-13T15:21:06.552996Z",
+     "iopub.status.idle": "2023-04-13T15:21:06.656732Z",
+     "shell.execute_reply": "2023-04-13T15:21:06.651324Z"
     },
     "papermill": {
-     "duration": 0.08633,
-     "end_time": "2023-04-13T15:03:24.309507",
+     "duration": 0.116379,
+     "end_time": "2023-04-13T15:21:06.661678",
      "exception": false,
-     "start_time": "2023-04-13T15:03:24.223177",
+     "start_time": "2023-04-13T15:21:06.545299",
      "status": "completed"
     },
     "tags": []
@@ -82,10 +82,10 @@
    "id": "2ba1ded0",
    "metadata": {
     "papermill": {
-     "duration": 0.006545,
-     "end_time": "2023-04-13T15:03:24.319882",
+     "duration": 0.006911,
+     "end_time": "2023-04-13T15:21:06.673195",
      "exception": false,
-     "start_time": "2023-04-13T15:03:24.313337",
+     "start_time": "2023-04-13T15:21:06.666284",
      "status": "completed"
     },
     "tags": []
@@ -100,16 +100,16 @@
    "id": "a08d2a1f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-04-13T15:03:24.327772Z",
-     "iopub.status.busy": "2023-04-13T15:03:24.327433Z",
-     "iopub.status.idle": "2023-04-13T15:03:24.357490Z",
-     "shell.execute_reply": "2023-04-13T15:03:24.343256Z"
+     "iopub.execute_input": "2023-04-13T15:21:06.681737Z",
+     "iopub.status.busy": "2023-04-13T15:21:06.681343Z",
+     "iopub.status.idle": "2023-04-13T15:21:06.701261Z",
+     "shell.execute_reply": "2023-04-13T15:21:06.695237Z"
     },
     "papermill": {
-     "duration": 0.042434,
-     "end_time": "2023-04-13T15:03:24.364466",
+     "duration": 0.031466,
+     "end_time": "2023-04-13T15:21:06.708723",
      "exception": false,
-     "start_time": "2023-04-13T15:03:24.322032",
+     "start_time": "2023-04-13T15:21:06.677257",
      "status": "completed"
     },
     "tags": []
@@ -137,10 +137,10 @@
    "id": "bb3fb301",
    "metadata": {
     "papermill": {
-     "duration": 0.003426,
-     "end_time": "2023-04-13T15:03:24.372125",
+     "duration": 0.001487,
+     "end_time": "2023-04-13T15:21:06.714456",
      "exception": false,
-     "start_time": "2023-04-13T15:03:24.368699",
+     "start_time": "2023-04-13T15:21:06.712969",
      "status": "completed"
     },
     "tags": []
@@ -155,16 +155,16 @@
    "id": "1e13a30f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-04-13T15:03:24.378031Z",
-     "iopub.status.busy": "2023-04-13T15:03:24.377625Z",
-     "iopub.status.idle": "2023-04-13T15:03:24.384186Z",
-     "shell.execute_reply": "2023-04-13T15:03:24.383359Z"
+     "iopub.execute_input": "2023-04-13T15:21:06.719154Z",
+     "iopub.status.busy": "2023-04-13T15:21:06.718732Z",
+     "iopub.status.idle": "2023-04-13T15:21:06.725912Z",
+     "shell.execute_reply": "2023-04-13T15:21:06.725146Z"
     },
     "papermill": {
-     "duration": 0.012828,
-     "end_time": "2023-04-13T15:03:24.387328",
+     "duration": 0.012548,
+     "end_time": "2023-04-13T15:21:06.728424",
      "exception": false,
-     "start_time": "2023-04-13T15:03:24.374500",
+     "start_time": "2023-04-13T15:21:06.715876",
      "status": "completed"
     },
     "tags": []
@@ -192,10 +192,10 @@
    "id": "98d00a0f",
    "metadata": {
     "papermill": {
-     "duration": 0.001276,
-     "end_time": "2023-04-13T15:03:24.390610",
+     "duration": 0.003317,
+     "end_time": "2023-04-13T15:21:06.735433",
      "exception": false,
-     "start_time": "2023-04-13T15:03:24.389334",
+     "start_time": "2023-04-13T15:21:06.732116",
      "status": "completed"
     },
     "tags": []
@@ -210,16 +210,16 @@
    "id": "916f8122",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-04-13T15:03:24.400119Z",
-     "iopub.status.busy": "2023-04-13T15:03:24.399579Z",
-     "iopub.status.idle": "2023-04-13T15:03:30.930802Z",
-     "shell.execute_reply": "2023-04-13T15:03:30.930452Z"
+     "iopub.execute_input": "2023-04-13T15:21:06.744348Z",
+     "iopub.status.busy": "2023-04-13T15:21:06.743756Z",
+     "iopub.status.idle": "2023-04-13T15:21:13.292705Z",
+     "shell.execute_reply": "2023-04-13T15:21:13.292307Z"
     },
     "papermill": {
-     "duration": 6.537529,
-     "end_time": "2023-04-13T15:03:30.931968",
+     "duration": 6.55503,
+     "end_time": "2023-04-13T15:21:13.293883",
      "exception": false,
-     "start_time": "2023-04-13T15:03:24.394439",
+     "start_time": "2023-04-13T15:21:06.738853",
      "status": "completed"
     },
     "tags": []
@@ -237,16 +237,16 @@
    "id": "756995ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-04-13T15:03:30.936255Z",
-     "iopub.status.busy": "2023-04-13T15:03:30.936065Z",
-     "iopub.status.idle": "2023-04-13T15:03:32.218543Z",
-     "shell.execute_reply": "2023-04-13T15:03:32.218208Z"
+     "iopub.execute_input": "2023-04-13T15:21:13.298209Z",
+     "iopub.status.busy": "2023-04-13T15:21:13.298003Z",
+     "iopub.status.idle": "2023-04-13T15:21:14.597676Z",
+     "shell.execute_reply": "2023-04-13T15:21:14.597350Z"
     },
     "papermill": {
-     "duration": 1.285295,
-     "end_time": "2023-04-13T15:03:32.219533",
+     "duration": 1.302618,
+     "end_time": "2023-04-13T15:21:14.598790",
      "exception": false,
-     "start_time": "2023-04-13T15:03:30.934238",
+     "start_time": "2023-04-13T15:21:13.296172",
      "status": "completed"
     },
     "tags": []
@@ -284,10 +284,10 @@
    "id": "67b9285c",
    "metadata": {
     "papermill": {
-     "duration": 0.001233,
-     "end_time": "2023-04-13T15:03:32.222317",
+     "duration": 0.001309,
+     "end_time": "2023-04-13T15:21:14.601775",
      "exception": false,
-     "start_time": "2023-04-13T15:03:32.221084",
+     "start_time": "2023-04-13T15:21:14.600466",
      "status": "completed"
     },
     "tags": []
@@ -302,16 +302,16 @@
    "id": "46c8833f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-04-13T15:03:32.225322Z",
-     "iopub.status.busy": "2023-04-13T15:03:32.225186Z",
-     "iopub.status.idle": "2023-04-13T15:03:33.163806Z",
-     "shell.execute_reply": "2023-04-13T15:03:33.163513Z"
+     "iopub.execute_input": "2023-04-13T15:21:14.605063Z",
+     "iopub.status.busy": "2023-04-13T15:21:14.604910Z",
+     "iopub.status.idle": "2023-04-13T15:21:15.529311Z",
+     "shell.execute_reply": "2023-04-13T15:21:15.528871Z"
     },
     "papermill": {
-     "duration": 0.941458,
-     "end_time": "2023-04-13T15:03:33.164943",
+     "duration": 0.927715,
+     "end_time": "2023-04-13T15:21:15.530740",
      "exception": false,
-     "start_time": "2023-04-13T15:03:32.223485",
+     "start_time": "2023-04-13T15:21:14.603025",
      "status": "completed"
     },
     "tags": []
@@ -347,10 +347,10 @@
    "id": "6546f023",
    "metadata": {
     "papermill": {
-     "duration": 0.001306,
-     "end_time": "2023-04-13T15:03:33.181123",
+     "duration": 0.001353,
+     "end_time": "2023-04-13T15:21:15.548960",
      "exception": false,
-     "start_time": "2023-04-13T15:03:33.179817",
+     "start_time": "2023-04-13T15:21:15.547607",
      "status": "completed"
     },
     "tags": []
@@ -378,14 +378,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 10.474924,
-   "end_time": "2023-04-13T15:03:33.803982",
+   "duration": 10.634813,
+   "end_time": "2023-04-13T15:21:16.272981",
    "environment_variables": {},
    "exception": null,
    "input_path": "docs/source/transforming_datasets.ipynb",
    "output_path": "docs/source/transforming_datasets.ipynb",
    "parameters": {},
-   "start_time": "2023-04-13T15:03:23.329058",
+   "start_time": "2023-04-13T15:21:05.638168",
    "version": "2.4.0"
   }
  },

--- a/docs/source/type_checking.ipynb
+++ b/docs/source/type_checking.ipynb
@@ -3,7 +3,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "a6b265df",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009949,
+     "end_time": "2023-04-13T15:21:17.528465",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:17.518516",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Type checking\n",
     "## Runtime\n",
@@ -13,8 +23,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": null,
+   "id": "24a21def",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:21:17.542803Z",
+     "iopub.status.busy": "2023-04-13T15:21:17.542521Z",
+     "iopub.status.idle": "2023-04-13T15:21:24.158807Z",
+     "shell.execute_reply": "2023-04-13T15:21:24.158395Z"
+    },
+    "papermill": {
+     "duration": 6.625156,
+     "end_time": "2023-04-13T15:21:24.160006",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:17.534850",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -26,8 +52,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": 2,
+   "id": "fd37a1d1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:21:24.163529Z",
+     "iopub.status.busy": "2023-04-13T15:21:24.163285Z",
+     "iopub.status.idle": "2023-04-13T15:21:26.327868Z",
+     "shell.execute_reply": "2023-04-13T15:21:26.327543Z"
+    },
+    "papermill": {
+     "duration": 2.167456,
+     "end_time": "2023-04-13T15:21:26.328956",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:24.161500",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -71,15 +113,41 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "c27a99fe",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001136,
+     "end_time": "2023-04-13T15:21:26.331615",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:26.330479",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "As a convention, we ignore any columns that start with `__` during this check."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
+   "execution_count": 3,
+   "id": "b99e82f8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:21:26.334674Z",
+     "iopub.status.busy": "2023-04-13T15:21:26.334526Z",
+     "iopub.status.idle": "2023-04-13T15:21:26.484201Z",
+     "shell.execute_reply": "2023-04-13T15:21:26.483829Z"
+    },
+    "papermill": {
+     "duration": 0.152528,
+     "end_time": "2023-04-13T15:21:26.485268",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:26.332740",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -114,8 +182,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
+   "execution_count": 4,
+   "id": "baa96cfa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:21:26.488960Z",
+     "iopub.status.busy": "2023-04-13T15:21:26.488819Z",
+     "iopub.status.idle": "2023-04-13T15:21:26.507096Z",
+     "shell.execute_reply": "2023-04-13T15:21:26.506772Z"
+    },
+    "papermill": {
+     "duration": 0.02118,
+     "end_time": "2023-04-13T15:21:26.508079",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:26.486899",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -142,8 +226,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
+   "execution_count": 5,
+   "id": "71bfc3b9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:21:26.511294Z",
+     "iopub.status.busy": "2023-04-13T15:21:26.511170Z",
+     "iopub.status.idle": "2023-04-13T15:21:26.528147Z",
+     "shell.execute_reply": "2023-04-13T15:21:26.527778Z"
+    },
+    "papermill": {
+     "duration": 0.019712,
+     "end_time": "2023-04-13T15:21:26.529228",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:26.509516",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -173,7 +273,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "357c3f96",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001218,
+     "end_time": "2023-04-13T15:21:26.531921",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:26.530703",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Assuming your code is run regularly (e.g. through unit tests, scheduled pipelines, etc.), this means you can safely assume a `DataSet[Person]` object that you come across on the master branch indeed follows the indicated schema.\n",
     "\n",
@@ -183,8 +293,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
+   "execution_count": 6,
+   "id": "7e34671a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-04-13T15:21:26.535859Z",
+     "iopub.status.busy": "2023-04-13T15:21:26.535715Z",
+     "iopub.status.idle": "2023-04-13T15:21:26.665226Z",
+     "shell.execute_reply": "2023-04-13T15:21:26.664883Z"
+    },
+    "papermill": {
+     "duration": 0.133324,
+     "end_time": "2023-04-13T15:21:26.666467",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:26.533143",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "class Person(Schema):\n",
@@ -250,7 +376,17 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "30738286",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001288,
+     "end_time": "2023-04-13T15:21:26.669393",
+     "exception": false,
+     "start_time": "2023-04-13T15:21:26.668105",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": []
   }
  ],
@@ -272,8 +408,19 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.16"
   },
-  "orig_nbformat": 4
+  "papermill": {
+   "default_parameters": {},
+   "duration": 10.775069,
+   "end_time": "2023-04-13T15:21:27.393727",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "docs/source/type_checking.ipynb",
+   "output_path": "docs/source/type_checking.ipynb",
+   "parameters": {},
+   "start_time": "2023-04-13T15:21:16.618658",
+   "version": "2.4.0"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/docs/source/type_checking.ipynb
+++ b/docs/source/type_checking.ipynb
@@ -25,16 +25,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -47,6 +40,13 @@
       "|  3|Jack| 40|\n",
       "+---+----+---+\n",
       "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
      ]
     }
    ],
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -148,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -189,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/source/type_checking.ipynb
+++ b/docs/source/type_checking.ipynb
@@ -20,7 +20,8 @@
     "import warnings\n",
     "from pyspark.sql import SparkSession \n",
     "warnings.filterwarnings('ignore')\n",
-    "spark = SparkSession.Builder().getOrCreate()"
+    "spark = SparkSession.Builder().getOrCreate()\n",
+    "spark.sparkContext.setLogLevel(\"ERROR\")"
    ]
   },
   {
@@ -40,13 +41,6 @@
       "|  3|Jack| 40|\n",
       "+---+----+---+\n",
       "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
      ]
     }
    ],


### PR DESCRIPTION
* Remove warnings and progress bars that pyspark gives
  * They weren't very informative, and would often be printed in red, which was distracting
* Give the documentation about generating schemas at runtime its own page 

You can see the generated documentation here:
https://typedspark.readthedocs.io/en/rerun-all-notebooks/