### PR TITLE
Support nested datatypes for Schema.get_schema_definition_as_string()

### DIFF
--- a/tests/_schema/test_schema.py
+++ b/tests/_schema/test_schema.py
@@ -52,7 +52,7 @@ class Values(Schema):
 class ComplexDatatypes(Schema):
     value: Column[typedspark.StructType[Values]]
     items: Column[typedspark.ArrayType[StringType]]
-    consequences: Column[typedspark.MapType[StringType, StringType]]
+    consequences: Column[typedspark.MapType[StringType, typedspark.ArrayType[StringType]]]
 
 
 schema_complex_datatypes = '''from typing import Annotated, Literal
@@ -67,7 +67,7 @@ class ComplexDatatypes(Schema):
 
     value: Annotated[Column[StructType[test_schema.Values]], ColumnMeta(comment="")]
     items: Annotated[Column[ArrayType[StringType]], ColumnMeta(comment="")]
-    consequences: Annotated[Column[MapType[StringType, StringType]], ColumnMeta(comment="")]
+    consequences: Annotated[Column[MapType[StringType, ArrayType[StringType]]], ColumnMeta(comment="")]
 
 
 class Values(Schema):
@@ -75,7 +75,7 @@ class Values(Schema):
 
     a: Annotated[Column[DecimalType[Literal[38], Literal[18]]], ColumnMeta(comment="")]
     b: Annotated[Column[StringType], ColumnMeta(comment="")]
-'''
+'''  # noqa: E501
 
 
 class PascalCase(Schema):

--- a/typedspark/_schema/get_schema_imports.py
+++ b/typedspark/_schema/get_schema_imports.py
@@ -38,6 +38,10 @@ def _get_imported_dtypes(schema: Type[Schema]) -> set[Type[DataType]]:
 
 
 def _process_datatype(dtype: Type[DataType]) -> set[Type[DataType]]:
+    """Returns a set of DataTypes that are imported for a given DataType.
+
+    Handles nested DataTypes recursively.
+    """
     encountered_datatypes: set[Type[DataType]] = set()
 
     origin: Optional[Type[DataType]] = get_origin(dtype)


### PR DESCRIPTION
Currently, the following code gives an error:

```python
class A(Schema):
    a: Column[ArrayType[ArrayType[StringType]]]

A.get_schema_definition_as_string()
```

This PR fixes that error.