### PR TITLE
fix setup java in cicd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-            distribution: 'oracle'
+            distribution: 'temurin'
             java-version: 11
       - uses: vemonet/setup-spark@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+            distribution: 'oracle'
             java-version: 11
       - uses: vemonet/setup-spark@v1
         with:


### PR DESCRIPTION
`actions/setup-java@v1` seems to be broken now that `Node.js 12 actions are deprecated`, updating to `v2`.