### PR TITLE
strip notebooks of metadata

### DIFF
--- a/docs/remove_metadata.py
+++ b/docs/remove_metadata.py
@@ -1,0 +1,49 @@
+"""Removes the metadata from a notebook.
+
+Also removes the spark warnings from cells where the sparksession is
+initialized.
+"""
+import sys
+
+import nbformat
+
+
+def clear_metadata(cell):
+    """Clears the metadata of a notebook cell."""
+    cell.metadata = {}
+
+
+def remove_spark_warnings(cell):
+    """Removes the spark warnings from a notebook cell."""
+    if "outputs" in cell.keys():
+        outputs = []
+        for output in cell.outputs:
+            if 'Setting default log level to "WARN"' in output.text:
+                continue
+            if (
+                "WARN NativeCodeLoader: Unable to load native-hadoop library for your platform."
+                in output.text
+            ):
+                continue
+            outputs.append(output)
+
+        cell.outputs = outputs
+
+
+def remove_papermill_metadata(nb):
+    """Removes the papermill metadata from a notebook."""
+    if "papermill" in nb.metadata.keys():
+        nb.metadata.pop("papermill")
+
+
+if __name__ == "__main__":
+    FILENAME = sys.argv[1]
+    nb = nbformat.read(FILENAME, as_version=4)
+
+    for cell in nb["cells"]:
+        clear_metadata(cell)
+        remove_spark_warnings(cell)
+
+    remove_papermill_metadata(nb)
+
+    nbformat.write(nb, FILENAME)

--- a/docs/remove_metadata.py
+++ b/docs/remove_metadata.py
@@ -18,6 +18,8 @@ def remove_spark_warnings(cell):
     if "outputs" in cell.keys():
         outputs = []
         for output in cell.outputs:
+            if "text" not in output.keys():
+                continue
             if 'Setting default log level to "WARN"' in output.text:
                 continue
             if (

--- a/docs/run_notebooks.sh
+++ b/docs/run_notebooks.sh
@@ -1,0 +1,4 @@
+for FILE in docs/source/*.ipynb; do 
+    papermill $FILE $FILE; 
+    python docs/remove_metadata.py $FILE;
+done

--- a/docs/source/advanced_linting_support.ipynb
+++ b/docs/source/advanced_linting_support.ipynb
@@ -25,22 +25,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bdf75d36",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:09:41.952818Z",
-     "iopub.status.busy": "2023-04-17T15:09:41.952623Z",
-     "iopub.status.idle": "2023-04-17T15:09:48.563366Z",
-     "shell.execute_reply": "2023-04-17T15:09:48.563022Z"
-    },
-    "papermill": {
-     "duration": 6.614384,
-     "end_time": "2023-04-17T15:09:48.564409",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:41.950025",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
@@ -52,22 +37,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "c84b26e9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:09:48.567589Z",
-     "iopub.status.busy": "2023-04-17T15:09:48.567455Z",
-     "iopub.status.idle": "2023-04-17T15:09:49.868250Z",
-     "shell.execute_reply": "2023-04-17T15:09:49.867887Z"
-    },
-    "papermill": {
-     "duration": 1.303523,
-     "end_time": "2023-04-17T15:09:49.869396",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:48.565873",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from typedspark import Column, Schema, DataSet, create_partially_filled_dataset\n",
@@ -104,22 +74,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "b0fe9344",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:09:49.874895Z",
-     "iopub.status.busy": "2023-04-17T15:09:49.874762Z",
-     "iopub.status.idle": "2023-04-17T15:09:49.876661Z",
-     "shell.execute_reply": "2023-04-17T15:09:49.876409Z"
-    },
-    "papermill": {
-     "duration": 0.004388,
-     "end_time": "2023-04-17T15:09:49.877527",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:49.873139",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def foo(df: DataSet[A]) -> DataSet[A]:\n",
@@ -156,22 +111,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "3abfb0d8",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:09:49.882393Z",
-     "iopub.status.busy": "2023-04-17T15:09:49.882282Z",
-     "iopub.status.idle": "2023-04-17T15:09:49.929606Z",
-     "shell.execute_reply": "2023-04-17T15:09:49.929339Z"
-    },
-    "papermill": {
-     "duration": 0.04976,
-     "end_time": "2023-04-17T15:09:49.930566",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:49.880806",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df_a = create_partially_filled_dataset(spark, A, {A.a: [\"a\", \"b\", \"c\"]})\n",
@@ -209,22 +149,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "5b0df362",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:09:49.935323Z",
-     "iopub.status.busy": "2023-04-17T15:09:49.935218Z",
-     "iopub.status.idle": "2023-04-17T15:09:49.964137Z",
-     "shell.execute_reply": "2023-04-17T15:09:49.963846Z"
-    },
-    "papermill": {
-     "duration": 0.0312,
-     "end_time": "2023-04-17T15:09:49.965036",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:49.933836",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from typedspark import transform_to_schema\n",
@@ -285,34 +210,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "typedspark",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.2"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 9.638315,
-   "end_time": "2023-04-17T15:09:50.693163",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "docs/source/advanced_linting_support.ipynb",
-   "output_path": "docs/source/advanced_linting_support.ipynb",
-   "parameters": {},
-   "start_time": "2023-04-17T15:09:41.054848",
-   "version": "2.4.0"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/docs/source/advanced_linting_support.ipynb
+++ b/docs/source/advanced_linting_support.ipynb
@@ -4,16 +4,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "b83251c2",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00282,
-     "end_time": "2023-04-17T15:09:41.947810",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:41.944990",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Advanced type-checking using linters\n",
     "## Functions that do not affect the schema\n",
@@ -23,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "bdf75d36",
    "metadata": {},
    "outputs": [],
@@ -54,16 +45,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "01675118",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001128,
-     "end_time": "2023-04-17T15:09:49.872010",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:49.870882",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "In the above example, `filter()` will not actually make any changes to the schema, hence we have implemented the return type of `DataSet.filter()` to be a `DataSet` of the same `Schema` that you started with. In other words, a linter will see that `res` is of the type `DataSet[A]`.\n",
     "\n",
@@ -85,16 +67,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "4ed27a7d",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001032,
-     "end_time": "2023-04-17T15:09:49.879767",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:49.878735",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "The functions for which this is currently implemented include:\n",
     "\n",
@@ -124,16 +97,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "dfa33e61",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001035,
-     "end_time": "2023-04-17T15:09:49.932880",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:49.931845",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "The functions in this category include:\n",
     "\n",
@@ -177,16 +141,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "4221be22",
-   "metadata": {
-    "papermill": {
-     "duration": 0.000986,
-     "end_time": "2023-04-17T15:09:49.967196",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:49.966210",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## Did we miss anything?\n",
     "\n",
@@ -196,22 +151,27 @@
   {
    "cell_type": "markdown",
    "id": "d21ad841",
-   "metadata": {
-    "papermill": {
-     "duration": 0.000999,
-     "end_time": "2023-04-17T15:09:49.969197",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:49.968198",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": []
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "typedspark",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/autocomplete_in_databricks.ipynb
+++ b/docs/source/autocomplete_in_databricks.ipynb
@@ -4,16 +4,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "c3322756",
-   "metadata": {
-    "papermill": {
-     "duration": 0.017565,
-     "end_time": "2023-04-17T15:09:51.912957",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:51.895392",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Autocomplete in Databricks notebooks\n",
     "When we use `load_table()` on Databricks, it also offers autocomplete on the column names. No more looking at `df.columns` every minute to remember the column names!\n",
@@ -23,24 +14,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "87752202",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:09:51.922229Z",
-     "iopub.status.busy": "2023-04-17T15:09:51.921644Z",
-     "iopub.status.idle": "2023-04-17T15:09:58.460913Z",
-     "shell.execute_reply": "2023-04-17T15:09:58.460604Z"
-    },
-    "papermill": {
-     "duration": 6.545568,
-     "end_time": "2023-04-17T15:09:58.461991",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:51.916423",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
@@ -52,22 +28,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "6c1e5acc",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:09:58.465082Z",
-     "iopub.status.busy": "2023-04-17T15:09:58.464940Z",
-     "iopub.status.idle": "2023-04-17T15:09:59.896245Z",
-     "shell.execute_reply": "2023-04-17T15:09:59.895956Z"
-    },
-    "papermill": {
-     "duration": 1.43395,
-     "end_time": "2023-04-17T15:09:59.897319",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:58.463369",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -89,16 +50,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "4bd96763",
-   "metadata": {
-    "papermill": {
-     "duration": 0.000993,
-     "end_time": "2023-04-17T15:09:59.899654",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:59.898661",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "We can now load these data using `load_table()`. Note that the `Schema` is inferred: it doesn't need to have been serialized using `typedspark`."
    ]
@@ -107,22 +59,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "3003dea9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:09:59.902125Z",
-     "iopub.status.busy": "2023-04-17T15:09:59.901954Z",
-     "iopub.status.idle": "2023-04-17T15:09:59.923886Z",
-     "shell.execute_reply": "2023-04-17T15:09:59.923576Z"
-    },
-    "papermill": {
-     "duration": 0.024223,
-     "end_time": "2023-04-17T15:09:59.924794",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:59.900571",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from typedspark import load_table\n",
@@ -134,16 +71,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "65c183c1",
-   "metadata": {
-    "papermill": {
-     "duration": 0.000942,
-     "end_time": "2023-04-17T15:09:59.926932",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:59.925990",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "You can now use `df` and `Person` just like you would in your IDE, including autocomplete!"
    ]
@@ -152,22 +80,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "f38e0e20",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:09:59.929491Z",
-     "iopub.status.busy": "2023-04-17T15:09:59.929384Z",
-     "iopub.status.idle": "2023-04-17T15:10:01.004126Z",
-     "shell.execute_reply": "2023-04-17T15:10:01.003842Z"
-    },
-    "papermill": {
-     "duration": 1.077009,
-     "end_time": "2023-04-17T15:10:01.004973",
-     "exception": false,
-     "start_time": "2023-04-17T15:09:59.927964",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -195,16 +108,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "08f247d1",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001017,
-     "end_time": "2023-04-17T15:10:01.007359",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:01.006342",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "Of note, `load_table()` automatically runs `register_schema_to_dataset()` on the resulting `DataSet` and `Schema`, hence resolving potential column disambiguities.\n",
     "\n",
@@ -214,16 +118,7 @@
   {
    "cell_type": "markdown",
    "id": "534ee9d9",
-   "metadata": {
-    "papermill": {
-     "duration": 0.000962,
-     "end_time": "2023-04-17T15:10:01.009246",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:01.008284",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": []
   }
  ],
@@ -244,18 +139,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.2"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 10.738206,
-   "end_time": "2023-04-17T15:10:01.747534",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "docs/source/autocomplete_in_databricks.ipynb",
-   "output_path": "docs/source/autocomplete_in_databricks.ipynb",
-   "parameters": {},
-   "start_time": "2023-04-17T15:09:51.009328",
-   "version": "2.4.0"
   }
  },
  "nbformat": 4,

--- a/docs/source/column_ambiguity.ipynb
+++ b/docs/source/column_ambiguity.ipynb
@@ -4,16 +4,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "a836183d",
-   "metadata": {
-    "papermill": {
-     "duration": 0.009794,
-     "end_time": "2023-04-17T15:10:02.956164",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:02.946370",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Dealing with column ambiguity\n",
     "\n",
@@ -22,24 +13,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "ee6a97e4",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:02.973437Z",
-     "iopub.status.busy": "2023-04-17T15:10:02.972844Z",
-     "iopub.status.idle": "2023-04-17T15:10:09.572016Z",
-     "shell.execute_reply": "2023-04-17T15:10:09.571664Z"
-    },
-    "papermill": {
-     "duration": 6.606627,
-     "end_time": "2023-04-17T15:10:09.573092",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:02.966465",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
@@ -51,22 +27,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "6206d284",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:09.576125Z",
-     "iopub.status.busy": "2023-04-17T15:10:09.575976Z",
-     "iopub.status.idle": "2023-04-17T15:10:10.919986Z",
-     "shell.execute_reply": "2023-04-17T15:10:10.919703Z"
-    },
-    "papermill": {
-     "duration": 1.346473,
-     "end_time": "2023-04-17T15:10:10.920890",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:09.574417",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -103,16 +64,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "09be224a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001013,
-     "end_time": "2023-04-17T15:10:10.923275",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:10.922262",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "The above resulted in a `AnalysisException`, because Spark can't figure out whether `id` belongs to `df_a` or `df_b`. To deal with this, you need to register your `Schema` to the `DataSet`."
    ]
@@ -121,22 +73,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "459a5e06",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:10.925735Z",
-     "iopub.status.busy": "2023-04-17T15:10:10.925615Z",
-     "iopub.status.idle": "2023-04-17T15:10:12.413634Z",
-     "shell.execute_reply": "2023-04-17T15:10:12.413313Z"
-    },
-    "papermill": {
-     "duration": 1.490591,
-     "end_time": "2023-04-17T15:10:12.414770",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:10.924179",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -169,16 +106,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "8359bd08",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00105,
-     "end_time": "2023-04-17T15:10:12.417208",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:12.416158",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "It is often a good idea to drop the ambiguous column, for example:"
    ]
@@ -187,22 +115,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "e0f1a644",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:12.420283Z",
-     "iopub.status.busy": "2023-04-17T15:10:12.420163Z",
-     "iopub.status.idle": "2023-04-17T15:10:12.731812Z",
-     "shell.execute_reply": "2023-04-17T15:10:12.731538Z"
-    },
-    "papermill": {
-     "duration": 0.314389,
-     "end_time": "2023-04-17T15:10:12.732922",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:12.418533",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -239,16 +152,7 @@
   {
    "cell_type": "markdown",
    "id": "5b08a13f",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001079,
-     "end_time": "2023-04-17T15:10:12.735433",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:12.734354",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": []
   }
  ],
@@ -269,18 +173,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.2"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 11.417202,
-   "end_time": "2023-04-17T15:10:13.472736",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "docs/source/column_ambiguity.ipynb",
-   "output_path": "docs/source/column_ambiguity.ipynb",
-   "parameters": {},
-   "start_time": "2023-04-17T15:10:02.055534",
-   "version": "2.4.0"
   }
  },
  "nbformat": 4,

--- a/docs/source/complex_datatypes.ipynb
+++ b/docs/source/complex_datatypes.ipynb
@@ -4,16 +4,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "72077ffb",
-   "metadata": {
-    "papermill": {
-     "duration": 0.008784,
-     "end_time": "2023-04-17T15:10:14.688109",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:14.679325",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Complex datatypes\n",
     "Spark contains several data types that are slightly more complex. \n",
@@ -26,22 +17,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "934c2a2d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:14.699374Z",
-     "iopub.status.busy": "2023-04-17T15:10:14.698733Z",
-     "iopub.status.idle": "2023-04-17T15:10:14.812485Z",
-     "shell.execute_reply": "2023-04-17T15:10:14.811595Z"
-    },
-    "papermill": {
-     "duration": 0.121928,
-     "end_time": "2023-04-17T15:10:14.815230",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:14.693302",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from pyspark.sql.types import StringType\n",
@@ -61,16 +37,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "271da325",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002244,
-     "end_time": "2023-04-17T15:10:14.820296",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:14.818052",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## DecimalType\n",
     "\n",
@@ -81,22 +48,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "3ccb56ff",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:14.825444Z",
-     "iopub.status.busy": "2023-04-17T15:10:14.825095Z",
-     "iopub.status.idle": "2023-04-17T15:10:14.831345Z",
-     "shell.execute_reply": "2023-04-17T15:10:14.830670Z"
-    },
-    "papermill": {
-     "duration": 0.011211,
-     "end_time": "2023-04-17T15:10:14.833799",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:14.822588",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from typing import Literal\n",
@@ -110,16 +62,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "8a2232b3",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001922,
-     "end_time": "2023-04-17T15:10:14.837978",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:14.836056",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## Did we miss a data type?\n",
     "\n",
@@ -129,16 +72,7 @@
   {
    "cell_type": "markdown",
    "id": "33d83e5f",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002008,
-     "end_time": "2023-04-17T15:10:14.841890",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:14.839882",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": []
   }
  ],
@@ -159,18 +93,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.2"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 1.278891,
-   "end_time": "2023-04-17T15:10:15.067407",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "docs/source/complex_datatypes.ipynb",
-   "output_path": "docs/source/complex_datatypes.ipynb",
-   "parameters": {},
-   "start_time": "2023-04-17T15:10:13.788516",
-   "version": "2.4.0"
   }
  },
  "nbformat": 4,

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -24,7 +24,7 @@ Note that in order to run the unit tests, you will need to set up Spark on your 
 ---------
 Notebooks
 ---------
-If you make changes that affect the documentation, please rerun the documentation notebooks in ``docs/source/``. You can do so by runningthe following command in the root of the repository:
+If you make changes that affect the documentation, please rerun the documentation notebooks in ``docs/source/``. You can do so by running the following command in the root of the repository:
 
 .. code-block:: bash
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -20,3 +20,14 @@ To set up the environment, run:
 For a list of currently supported Python versions, as well as the various CI/CD steps, we refer to ``.github/workflows/build.yml``.
 
 Note that in order to run the unit tests, you will need to set up Spark on your machine.
+
+---------
+Notebooks
+---------
+If you make changes that affect the documentation, please rerun the documentation notebooks in ``docs/source/``. You can do so by runningthe following command in the root of the repository:
+
+.. code-block:: bash
+
+    sh docs/run_notebooks.sh
+
+This will run all notebooks and strip the metadata afterwards, such that the diffs in the PR remain manageable.

--- a/docs/source/create_empty_datasets.ipynb
+++ b/docs/source/create_empty_datasets.ipynb
@@ -4,16 +4,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "f25abb69",
-   "metadata": {
-    "papermill": {
-     "duration": 0.011439,
-     "end_time": "2023-04-17T15:10:16.291714",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:16.280275",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Easier unit testing through the creation of empty DataSets from schemas\n",
     "We provide helper functions to generate (partially) empty DataSets from existing schemas. This can be helpful in certain situations, such as unit testing."
@@ -21,24 +12,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "25b679fc",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:16.303916Z",
-     "iopub.status.busy": "2023-04-17T15:10:16.303577Z",
-     "iopub.status.idle": "2023-04-17T15:10:22.920830Z",
-     "shell.execute_reply": "2023-04-17T15:10:22.920539Z"
-    },
-    "papermill": {
-     "duration": 6.624263,
-     "end_time": "2023-04-17T15:10:22.921881",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:16.297618",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
@@ -50,22 +26,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "7a2690c7",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:22.925670Z",
-     "iopub.status.busy": "2023-04-17T15:10:22.925514Z",
-     "iopub.status.idle": "2023-04-17T15:10:25.283278Z",
-     "shell.execute_reply": "2023-04-17T15:10:25.282919Z"
-    },
-    "papermill": {
-     "duration": 2.360643,
-     "end_time": "2023-04-17T15:10:25.284256",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:22.923613",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -99,22 +60,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "d5ce76e1",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:25.287919Z",
-     "iopub.status.busy": "2023-04-17T15:10:25.287786Z",
-     "iopub.status.idle": "2023-04-17T15:10:25.515863Z",
-     "shell.execute_reply": "2023-04-17T15:10:25.515567Z"
-    },
-    "papermill": {
-     "duration": 0.231059,
-     "end_time": "2023-04-17T15:10:25.517035",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:25.285976",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -147,16 +93,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "74e41042",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001411,
-     "end_time": "2023-04-17T15:10:25.520236",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:25.518825",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## Complex datatypes\n",
     "\n",
@@ -167,22 +104,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "3578c0e5",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:25.523706Z",
-     "iopub.status.busy": "2023-04-17T15:10:25.523488Z",
-     "iopub.status.idle": "2023-04-17T15:10:25.957968Z",
-     "shell.execute_reply": "2023-04-17T15:10:25.957695Z"
-    },
-    "papermill": {
-     "duration": 0.437352,
-     "end_time": "2023-04-17T15:10:25.958948",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:25.521596",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -231,22 +153,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "e2d3b302",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:25.962879Z",
-     "iopub.status.busy": "2023-04-17T15:10:25.962759Z",
-     "iopub.status.idle": "2023-04-17T15:10:26.199825Z",
-     "shell.execute_reply": "2023-04-17T15:10:26.199523Z"
-    },
-    "papermill": {
-     "duration": 0.239937,
-     "end_time": "2023-04-17T15:10:26.200697",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:25.960760",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -286,16 +193,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "571cf714",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00137,
-     "end_time": "2023-04-17T15:10:26.203761",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:26.202391",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## Row-wise definition of your DataSets\n",
     "\n",
@@ -306,22 +204,7 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "a68e52bf",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:26.206985Z",
-     "iopub.status.busy": "2023-04-17T15:10:26.206873Z",
-     "iopub.status.idle": "2023-04-17T15:10:26.434774Z",
-     "shell.execute_reply": "2023-04-17T15:10:26.434487Z"
-    },
-    "papermill": {
-     "duration": 0.230564,
-     "end_time": "2023-04-17T15:10:26.435674",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:26.205110",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -362,16 +245,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "8621aaf1",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001424,
-     "end_time": "2023-04-17T15:10:26.438866",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:26.437442",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "This format also works for the complex data types:"
    ]
@@ -380,22 +254,7 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "bb8ab22f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:26.442826Z",
-     "iopub.status.busy": "2023-04-17T15:10:26.442711Z",
-     "iopub.status.idle": "2023-04-17T15:10:26.665659Z",
-     "shell.execute_reply": "2023-04-17T15:10:26.665384Z"
-    },
-    "papermill": {
-     "duration": 0.226339,
-     "end_time": "2023-04-17T15:10:26.666529",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:26.440190",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -442,16 +301,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "bd5c7c1c",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001484,
-     "end_time": "2023-04-17T15:10:26.669844",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:26.668360",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## Example unit test\n",
     "\n",
@@ -462,22 +312,7 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "f80ddebf",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:26.673310Z",
-     "iopub.status.busy": "2023-04-17T15:10:26.673190Z",
-     "iopub.status.idle": "2023-04-17T15:10:26.680377Z",
-     "shell.execute_reply": "2023-04-17T15:10:26.680109Z"
-    },
-    "papermill": {
-     "duration": 0.009973,
-     "end_time": "2023-04-17T15:10:26.681237",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:26.671264",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
@@ -511,16 +346,7 @@
   {
    "cell_type": "markdown",
    "id": "f5e716a8",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001503,
-     "end_time": "2023-04-17T15:10:26.700931",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:26.699428",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": []
   }
  ],
@@ -541,18 +367,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.2"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 13.079447,
-   "end_time": "2023-04-17T15:10:28.455184",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "docs/source/create_empty_datasets.ipynb",
-   "output_path": "docs/source/create_empty_datasets.ipynb",
-   "parameters": {},
-   "start_time": "2023-04-17T15:10:15.375737",
-   "version": "2.4.0"
   }
  },
  "nbformat": 4,

--- a/docs/source/documentation.ipynb
+++ b/docs/source/documentation.ipynb
@@ -4,16 +4,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "4b8cb87a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.0074,
-     "end_time": "2023-04-17T15:10:29.667736",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:29.660336",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Documentation of tables\n",
     "You can add documentation to schemas as follows:"
@@ -23,22 +14,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "d2e1e850",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:29.676617Z",
-     "iopub.status.busy": "2023-04-17T15:10:29.676261Z",
-     "iopub.status.idle": "2023-04-17T15:10:29.791740Z",
-     "shell.execute_reply": "2023-04-17T15:10:29.790899Z"
-    },
-    "papermill": {
-     "duration": 0.122837,
-     "end_time": "2023-04-17T15:10:29.794398",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:29.671561",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from typing import Annotated\n",
@@ -69,16 +45,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "302ad462",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001627,
-     "end_time": "2023-04-17T15:10:29.798639",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:29.797012",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "If you use Databricks and Delta Live Tables, you can make the documentation appear in the Databricks UI by using the following Delta Live Table definition:\n",
     "\n",
@@ -92,16 +59,7 @@
   {
    "cell_type": "markdown",
    "id": "17c2b1a6",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001389,
-     "end_time": "2023-04-17T15:10:29.801828",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:29.800439",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": []
   }
  ],
@@ -122,18 +80,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.2"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 1.156978,
-   "end_time": "2023-04-17T15:10:29.925459",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "docs/source/documentation.ipynb",
-   "output_path": "docs/source/documentation.ipynb",
-   "parameters": {},
-   "start_time": "2023-04-17T15:10:28.768481",
-   "version": "2.4.0"
   }
  },
  "nbformat": 4,

--- a/docs/source/generating_schemas.ipynb
+++ b/docs/source/generating_schemas.ipynb
@@ -4,16 +4,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "a006aaea",
-   "metadata": {
-    "papermill": {
-     "duration": 0.017882,
-     "end_time": "2023-04-20T12:59:07.708359",
-     "exception": false,
-     "start_time": "2023-04-20T12:59:07.690477",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Dynamically generate Schemas from existing tables\n",
     "You can dynamically load a `DataSet` and its corresponding `Schema` from an existing table. To illustrate this, let us first make a temporary table that we can load later."
@@ -23,39 +14,8 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "5442cec0",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-20T12:59:07.721845Z",
-     "iopub.status.busy": "2023-04-20T12:59:07.721474Z",
-     "iopub.status.idle": "2023-04-20T12:59:14.500214Z",
-     "shell.execute_reply": "2023-04-20T12:59:14.499863Z"
-    },
-    "papermill": {
-     "duration": 6.787453,
-     "end_time": "2023-04-20T12:59:14.501494",
-     "exception": false,
-     "start_time": "2023-04-20T12:59:07.714041",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Setting default log level to \"WARN\".\n",
-      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "23/04/20 14:59:13 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
     "spark = SparkSession.Builder().config(\"spark.ui.showConsoleProgress\", \"false\").getOrCreate()\n",
@@ -66,22 +26,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "0df943fb",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-20T12:59:14.505343Z",
-     "iopub.status.busy": "2023-04-20T12:59:14.505179Z",
-     "iopub.status.idle": "2023-04-20T12:59:16.126475Z",
-     "shell.execute_reply": "2023-04-20T12:59:16.126071Z"
-    },
-    "papermill": {
-     "duration": 1.624414,
-     "end_time": "2023-04-20T12:59:16.127658",
-     "exception": false,
-     "start_time": "2023-04-20T12:59:14.503244",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -103,16 +48,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "10524400",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001347,
-     "end_time": "2023-04-20T12:59:16.130676",
-     "exception": false,
-     "start_time": "2023-04-20T12:59:16.129329",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "We can now load these data using `load_table()`. Note that the `Schema` is inferred: it doesn't need to have been serialized using `typedspark`."
    ]
@@ -121,22 +57,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "b6c659c6",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-20T12:59:16.133856Z",
-     "iopub.status.busy": "2023-04-20T12:59:16.133665Z",
-     "iopub.status.idle": "2023-04-20T12:59:16.158905Z",
-     "shell.execute_reply": "2023-04-20T12:59:16.158415Z"
-    },
-    "papermill": {
-     "duration": 0.028301,
-     "end_time": "2023-04-20T12:59:16.160132",
-     "exception": false,
-     "start_time": "2023-04-20T12:59:16.131831",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from typedspark import load_table\n",
@@ -148,16 +69,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "51e4792d",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001267,
-     "end_time": "2023-04-20T12:59:16.162961",
-     "exception": false,
-     "start_time": "2023-04-20T12:59:16.161694",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "From here, it's trivial to generate the `Schema` for this table."
    ]
@@ -166,42 +78,8 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "defb2a82",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-20T12:59:16.165999Z",
-     "iopub.status.busy": "2023-04-20T12:59:16.165876Z",
-     "iopub.status.idle": "2023-04-20T12:59:16.169322Z",
-     "shell.execute_reply": "2023-04-20T12:59:16.169078Z"
-    },
-    "papermill": {
-     "duration": 0.005977,
-     "end_time": "2023-04-20T12:59:16.170186",
-     "exception": false,
-     "start_time": "2023-04-20T12:59:16.164209",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\n",
-       "from pyspark.sql.types import LongType, StringType\n",
-       "\n",
-       "from typedspark import Column, Schema\n",
-       "\n",
-       "\n",
-       "class DynamicallyLoadedSchema(Schema):\n",
-       "    name: Column[StringType]\n",
-       "    age: Column[LongType]"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "Person"
    ]
@@ -210,16 +88,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "bdaf1423",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001643,
-     "end_time": "2023-04-20T12:59:16.173368",
-     "exception": false,
-     "start_time": "2023-04-20T12:59:16.171725",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "To also generate documentation, run:"
    ]
@@ -228,22 +97,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "7305a079",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-20T12:59:16.176868Z",
-     "iopub.status.busy": "2023-04-20T12:59:16.176729Z",
-     "iopub.status.idle": "2023-04-20T12:59:16.178858Z",
-     "shell.execute_reply": "2023-04-20T12:59:16.178508Z"
-    },
-    "papermill": {
-     "duration": 0.004892,
-     "end_time": "2023-04-20T12:59:16.179696",
-     "exception": false,
-     "start_time": "2023-04-20T12:59:16.174804",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -273,16 +127,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "0f6ef71c",
-   "metadata": {
-    "papermill": {
-     "duration": 0.0013,
-     "end_time": "2023-04-20T12:59:16.182513",
-     "exception": false,
-     "start_time": "2023-04-20T12:59:16.181213",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "You can now use `df` and `Person` just like you would in your IDE. On Databricks, this also comes with an additional advantage: auto-complete on column names. No more looking at `df.columns` every minute to remember the column names!"
    ]
@@ -291,22 +136,7 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "9ef250c6",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-20T12:59:16.186006Z",
-     "iopub.status.busy": "2023-04-20T12:59:16.185795Z",
-     "iopub.status.idle": "2023-04-20T12:59:17.299298Z",
-     "shell.execute_reply": "2023-04-20T12:59:17.298991Z"
-    },
-    "papermill": {
-     "duration": 1.116358,
-     "end_time": "2023-04-20T12:59:17.300237",
-     "exception": false,
-     "start_time": "2023-04-20T12:59:16.183879",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -334,16 +164,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "15c03521",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00154,
-     "end_time": "2023-04-20T12:59:17.304389",
-     "exception": false,
-     "start_time": "2023-04-20T12:59:17.302849",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "Of note, `load_table()` automatically runs `register_schema_to_dataset()` on the resulting `DataSet` and `Schema`, hence resolving potential column disambiguities."
    ]
@@ -351,16 +172,7 @@
   {
    "cell_type": "markdown",
    "id": "18ea295c",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001454,
-     "end_time": "2023-04-20T12:59:17.307457",
-     "exception": false,
-     "start_time": "2023-04-20T12:59:17.306003",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": []
   }
  ],
@@ -381,18 +193,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.2"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 11.248666,
-   "end_time": "2023-04-20T12:59:18.030610",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "docs/source/generating_schemas.ipynb",
-   "output_path": "docs/source/generating_schemas.ipynb",
-   "parameters": {},
-   "start_time": "2023-04-20T12:59:06.781944",
-   "version": "2.4.0"
   }
  },
  "nbformat": 4,

--- a/docs/source/generating_schemas.ipynb
+++ b/docs/source/generating_schemas.ipynb
@@ -6,10 +6,10 @@
    "id": "a006aaea",
    "metadata": {
     "papermill": {
-     "duration": 0.010988,
-     "end_time": "2023-04-17T15:10:31.138624",
+     "duration": 0.017882,
+     "end_time": "2023-04-20T12:59:07.708359",
      "exception": false,
-     "start_time": "2023-04-17T15:10:31.127636",
+     "start_time": "2023-04-20T12:59:07.690477",
      "status": "completed"
     },
     "tags": []
@@ -21,25 +21,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "5442cec0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:31.150215Z",
-     "iopub.status.busy": "2023-04-17T15:10:31.149922Z",
-     "iopub.status.idle": "2023-04-17T15:10:37.773814Z",
-     "shell.execute_reply": "2023-04-17T15:10:37.773524Z"
+     "iopub.execute_input": "2023-04-20T12:59:07.721845Z",
+     "iopub.status.busy": "2023-04-20T12:59:07.721474Z",
+     "iopub.status.idle": "2023-04-20T12:59:14.500214Z",
+     "shell.execute_reply": "2023-04-20T12:59:14.499863Z"
     },
     "papermill": {
-     "duration": 6.630642,
-     "end_time": "2023-04-17T15:10:37.774826",
+     "duration": 6.787453,
+     "end_time": "2023-04-20T12:59:14.501494",
      "exception": false,
-     "start_time": "2023-04-17T15:10:31.144184",
+     "start_time": "2023-04-20T12:59:07.714041",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Setting default log level to \"WARN\".\n",
+      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "23/04/20 14:59:13 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
+     ]
+    }
+   ],
    "source": [
     "from pyspark.sql import SparkSession\n",
     "spark = SparkSession.Builder().config(\"spark.ui.showConsoleProgress\", \"false\").getOrCreate()\n",
@@ -52,16 +68,16 @@
    "id": "0df943fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:37.778330Z",
-     "iopub.status.busy": "2023-04-17T15:10:37.778190Z",
-     "iopub.status.idle": "2023-04-17T15:10:39.192150Z",
-     "shell.execute_reply": "2023-04-17T15:10:39.191864Z"
+     "iopub.execute_input": "2023-04-20T12:59:14.505343Z",
+     "iopub.status.busy": "2023-04-20T12:59:14.505179Z",
+     "iopub.status.idle": "2023-04-20T12:59:16.126475Z",
+     "shell.execute_reply": "2023-04-20T12:59:16.126071Z"
     },
     "papermill": {
-     "duration": 1.416756,
-     "end_time": "2023-04-17T15:10:39.193201",
+     "duration": 1.624414,
+     "end_time": "2023-04-20T12:59:16.127658",
      "exception": false,
-     "start_time": "2023-04-17T15:10:37.776445",
+     "start_time": "2023-04-20T12:59:14.503244",
      "status": "completed"
     },
     "tags": []
@@ -89,10 +105,10 @@
    "id": "10524400",
    "metadata": {
     "papermill": {
-     "duration": 0.001261,
-     "end_time": "2023-04-17T15:10:39.196030",
+     "duration": 0.001347,
+     "end_time": "2023-04-20T12:59:16.130676",
      "exception": false,
-     "start_time": "2023-04-17T15:10:39.194769",
+     "start_time": "2023-04-20T12:59:16.129329",
      "status": "completed"
     },
     "tags": []
@@ -107,16 +123,16 @@
    "id": "b6c659c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:39.198856Z",
-     "iopub.status.busy": "2023-04-17T15:10:39.198706Z",
-     "iopub.status.idle": "2023-04-17T15:10:39.219440Z",
-     "shell.execute_reply": "2023-04-17T15:10:39.219140Z"
+     "iopub.execute_input": "2023-04-20T12:59:16.133856Z",
+     "iopub.status.busy": "2023-04-20T12:59:16.133665Z",
+     "iopub.status.idle": "2023-04-20T12:59:16.158905Z",
+     "shell.execute_reply": "2023-04-20T12:59:16.158415Z"
     },
     "papermill": {
-     "duration": 0.023301,
-     "end_time": "2023-04-17T15:10:39.220427",
+     "duration": 0.028301,
+     "end_time": "2023-04-20T12:59:16.160132",
      "exception": false,
-     "start_time": "2023-04-17T15:10:39.197126",
+     "start_time": "2023-04-20T12:59:16.131831",
      "status": "completed"
     },
     "tags": []
@@ -134,10 +150,10 @@
    "id": "51e4792d",
    "metadata": {
     "papermill": {
-     "duration": 0.001123,
-     "end_time": "2023-04-17T15:10:39.222868",
+     "duration": 0.001267,
+     "end_time": "2023-04-20T12:59:16.162961",
      "exception": false,
-     "start_time": "2023-04-17T15:10:39.221745",
+     "start_time": "2023-04-20T12:59:16.161694",
      "status": "completed"
     },
     "tags": []
@@ -152,16 +168,16 @@
    "id": "defb2a82",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:39.225583Z",
-     "iopub.status.busy": "2023-04-17T15:10:39.225484Z",
-     "iopub.status.idle": "2023-04-17T15:10:39.228689Z",
-     "shell.execute_reply": "2023-04-17T15:10:39.228469Z"
+     "iopub.execute_input": "2023-04-20T12:59:16.165999Z",
+     "iopub.status.busy": "2023-04-20T12:59:16.165876Z",
+     "iopub.status.idle": "2023-04-20T12:59:16.169322Z",
+     "shell.execute_reply": "2023-04-20T12:59:16.169078Z"
     },
     "papermill": {
-     "duration": 0.005523,
-     "end_time": "2023-04-17T15:10:39.229520",
+     "duration": 0.005977,
+     "end_time": "2023-04-20T12:59:16.170186",
      "exception": false,
-     "start_time": "2023-04-17T15:10:39.223997",
+     "start_time": "2023-04-20T12:59:16.164209",
      "status": "completed"
     },
     "tags": []
@@ -196,10 +212,10 @@
    "id": "bdaf1423",
    "metadata": {
     "papermill": {
-     "duration": 0.001152,
-     "end_time": "2023-04-17T15:10:39.231965",
+     "duration": 0.001643,
+     "end_time": "2023-04-20T12:59:16.173368",
      "exception": false,
-     "start_time": "2023-04-17T15:10:39.230813",
+     "start_time": "2023-04-20T12:59:16.171725",
      "status": "completed"
     },
     "tags": []
@@ -214,16 +230,16 @@
    "id": "7305a079",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:39.234781Z",
-     "iopub.status.busy": "2023-04-17T15:10:39.234693Z",
-     "iopub.status.idle": "2023-04-17T15:10:39.236563Z",
-     "shell.execute_reply": "2023-04-17T15:10:39.236315Z"
+     "iopub.execute_input": "2023-04-20T12:59:16.176868Z",
+     "iopub.status.busy": "2023-04-20T12:59:16.176729Z",
+     "iopub.status.idle": "2023-04-20T12:59:16.178858Z",
+     "shell.execute_reply": "2023-04-20T12:59:16.178508Z"
     },
     "papermill": {
-     "duration": 0.004208,
-     "end_time": "2023-04-17T15:10:39.237314",
+     "duration": 0.004892,
+     "end_time": "2023-04-20T12:59:16.179696",
      "exception": false,
-     "start_time": "2023-04-17T15:10:39.233106",
+     "start_time": "2023-04-20T12:59:16.174804",
      "status": "completed"
     },
     "tags": []
@@ -259,10 +275,10 @@
    "id": "0f6ef71c",
    "metadata": {
     "papermill": {
-     "duration": 0.001196,
-     "end_time": "2023-04-17T15:10:39.239791",
+     "duration": 0.0013,
+     "end_time": "2023-04-20T12:59:16.182513",
      "exception": false,
-     "start_time": "2023-04-17T15:10:39.238595",
+     "start_time": "2023-04-20T12:59:16.181213",
      "status": "completed"
     },
     "tags": []
@@ -277,16 +293,16 @@
    "id": "9ef250c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:39.242600Z",
-     "iopub.status.busy": "2023-04-17T15:10:39.242511Z",
-     "iopub.status.idle": "2023-04-17T15:10:40.233079Z",
-     "shell.execute_reply": "2023-04-17T15:10:40.232779Z"
+     "iopub.execute_input": "2023-04-20T12:59:16.186006Z",
+     "iopub.status.busy": "2023-04-20T12:59:16.185795Z",
+     "iopub.status.idle": "2023-04-20T12:59:17.299298Z",
+     "shell.execute_reply": "2023-04-20T12:59:17.298991Z"
     },
     "papermill": {
-     "duration": 0.993031,
-     "end_time": "2023-04-17T15:10:40.234023",
+     "duration": 1.116358,
+     "end_time": "2023-04-20T12:59:17.300237",
      "exception": false,
-     "start_time": "2023-04-17T15:10:39.240992",
+     "start_time": "2023-04-20T12:59:16.183879",
      "status": "completed"
     },
     "tags": []
@@ -320,10 +336,10 @@
    "id": "15c03521",
    "metadata": {
     "papermill": {
-     "duration": 0.001269,
-     "end_time": "2023-04-17T15:10:40.237650",
+     "duration": 0.00154,
+     "end_time": "2023-04-20T12:59:17.304389",
      "exception": false,
-     "start_time": "2023-04-17T15:10:40.236381",
+     "start_time": "2023-04-20T12:59:17.302849",
      "status": "completed"
     },
     "tags": []
@@ -337,10 +353,10 @@
    "id": "18ea295c",
    "metadata": {
     "papermill": {
-     "duration": 0.00117,
-     "end_time": "2023-04-17T15:10:40.240013",
+     "duration": 0.001454,
+     "end_time": "2023-04-20T12:59:17.307457",
      "exception": false,
-     "start_time": "2023-04-17T15:10:40.238843",
+     "start_time": "2023-04-20T12:59:17.306003",
      "status": "completed"
     },
     "tags": []
@@ -368,14 +384,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 10.75381,
-   "end_time": "2023-04-17T15:10:40.982024",
+   "duration": 11.248666,
+   "end_time": "2023-04-20T12:59:18.030610",
    "environment_variables": {},
    "exception": null,
    "input_path": "docs/source/generating_schemas.ipynb",
    "output_path": "docs/source/generating_schemas.ipynb",
    "parameters": {},
-   "start_time": "2023-04-17T15:10:30.228214",
+   "start_time": "2023-04-20T12:59:06.781944",
    "version": "2.4.0"
   }
  },

--- a/docs/source/schema_attributes.ipynb
+++ b/docs/source/schema_attributes.ipynb
@@ -4,16 +4,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "011002f2",
-   "metadata": {
-    "papermill": {
-     "duration": 0.008318,
-     "end_time": "2023-04-17T15:10:42.197464",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:42.189146",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Auto-complete & easier refactoring using schema attributes \n",
     "Schemas allow us to replaces the numerous strings throughout the code by schema attributes. Consider the following example:"
@@ -23,22 +14,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "6379b38b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:42.206992Z",
-     "iopub.status.busy": "2023-04-17T15:10:42.206640Z",
-     "iopub.status.idle": "2023-04-17T15:10:42.322804Z",
-     "shell.execute_reply": "2023-04-17T15:10:42.322016Z"
-    },
-    "papermill": {
-     "duration": 0.124042,
-     "end_time": "2023-04-17T15:10:42.325715",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:42.201673",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from typedspark import Column, DataSet, Schema\n",
@@ -60,16 +36,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "a03a164a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002122,
-     "end_time": "2023-04-17T15:10:42.330745",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:42.328623",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "We can replace this with:"
    ]
@@ -78,22 +45,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "1e6fa606",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:42.336519Z",
-     "iopub.status.busy": "2023-04-17T15:10:42.336140Z",
-     "iopub.status.idle": "2023-04-17T15:10:42.341981Z",
-     "shell.execute_reply": "2023-04-17T15:10:42.341284Z"
-    },
-    "papermill": {
-     "duration": 0.0116,
-     "end_time": "2023-04-17T15:10:42.344396",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:42.332796",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def birthday(df: DataSet[Person]) -> DataSet[Person]:\n",
@@ -106,16 +58,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "4232e8ce",
-   "metadata": {
-    "papermill": {
-     "duration": 0.002038,
-     "end_time": "2023-04-17T15:10:42.348694",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:42.346656",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "Which allows:\n",
     "\n",
@@ -133,16 +76,7 @@
   {
    "cell_type": "markdown",
    "id": "4a56cffb",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001914,
-     "end_time": "2023-04-17T15:10:42.352691",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:42.350777",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": []
   }
  ],
@@ -163,18 +97,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.2"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 1.283542,
-   "end_time": "2023-04-17T15:10:42.577770",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "docs/source/schema_attributes.ipynb",
-   "output_path": "docs/source/schema_attributes.ipynb",
-   "parameters": {},
-   "start_time": "2023-04-17T15:10:41.294228",
-   "version": "2.4.0"
   }
  },
  "nbformat": 4,

--- a/docs/source/structtype_columns.ipynb
+++ b/docs/source/structtype_columns.ipynb
@@ -4,16 +4,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "913f374b",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006632,
-     "end_time": "2023-04-17T15:10:43.796516",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:43.789884",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Adding StructType columns\n",
     "\n",
@@ -22,24 +13,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "11cb3442",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:43.806640Z",
-     "iopub.status.busy": "2023-04-17T15:10:43.806235Z",
-     "iopub.status.idle": "2023-04-17T15:10:50.380124Z",
-     "shell.execute_reply": "2023-04-17T15:10:50.379809Z"
-    },
-    "papermill": {
-     "duration": 6.580195,
-     "end_time": "2023-04-17T15:10:50.381189",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:43.800994",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
@@ -51,22 +27,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "3e0bac9d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:50.384267Z",
-     "iopub.status.busy": "2023-04-17T15:10:50.384113Z",
-     "iopub.status.idle": "2023-04-17T15:10:52.825418Z",
-     "shell.execute_reply": "2023-04-17T15:10:52.825139Z"
-    },
-    "papermill": {
-     "duration": 2.443976,
-     "end_time": "2023-04-17T15:10:52.826549",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:50.382573",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -126,16 +87,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "0bcea41d",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00099,
-     "end_time": "2023-04-17T15:10:52.828898",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:52.827908",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "Just like in `transform_to_schema()`, the `transformations` dictionary in `structtype_column(..., transformations)` requires columns with unique names as keys."
    ]
@@ -144,22 +96,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "9c070a24",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:52.831355Z",
-     "iopub.status.busy": "2023-04-17T15:10:52.831216Z",
-     "iopub.status.idle": "2023-04-17T15:10:52.850190Z",
-     "shell.execute_reply": "2023-04-17T15:10:52.849924Z"
-    },
-    "papermill": {
-     "duration": 0.02124,
-     "end_time": "2023-04-17T15:10:52.851013",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:52.829773",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -193,16 +130,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "10b43a86",
-   "metadata": {
-    "papermill": {
-     "duration": 0.000967,
-     "end_time": "2023-04-17T15:10:52.853223",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:52.852256",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "Instead, combine these into a single line:"
    ]
@@ -211,22 +139,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "b88b95b0",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:52.855754Z",
-     "iopub.status.busy": "2023-04-17T15:10:52.855575Z",
-     "iopub.status.idle": "2023-04-17T15:10:53.094497Z",
-     "shell.execute_reply": "2023-04-17T15:10:53.094212Z"
-    },
-    "papermill": {
-     "duration": 0.241096,
-     "end_time": "2023-04-17T15:10:53.095332",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:52.854236",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -262,16 +175,7 @@
   {
    "cell_type": "markdown",
    "id": "acee3a29",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001016,
-     "end_time": "2023-04-17T15:10:53.097685",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:53.096669",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": []
   }
  ],
@@ -292,18 +196,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.2"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 10.934442,
-   "end_time": "2023-04-17T15:10:53.830839",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "docs/source/structtype_columns.ipynb",
-   "output_path": "docs/source/structtype_columns.ipynb",
-   "parameters": {},
-   "start_time": "2023-04-17T15:10:42.896397",
-   "version": "2.4.0"
   }
  },
  "nbformat": 4,

--- a/docs/source/subclassing_schemas.ipynb
+++ b/docs/source/subclassing_schemas.ipynb
@@ -4,16 +4,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "76ffac97",
-   "metadata": {
-    "papermill": {
-     "duration": 0.008204,
-     "end_time": "2023-04-17T15:10:55.040242",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:55.032038",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Subclassing schemas\n",
     "Subclassing schemas is a useful pattern for pipelines where every next function adds a few columns."
@@ -23,22 +14,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "7725965f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:55.056320Z",
-     "iopub.status.busy": "2023-04-17T15:10:55.055797Z",
-     "iopub.status.idle": "2023-04-17T15:10:55.164721Z",
-     "shell.execute_reply": "2023-04-17T15:10:55.163756Z"
-    },
-    "papermill": {
-     "duration": 0.123131,
-     "end_time": "2023-04-17T15:10:55.167776",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:55.044645",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from typedspark import Column, Schema, DataSet\n",
@@ -62,16 +38,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "cc265385",
-   "metadata": {
-    "papermill": {
-     "duration": 0.000947,
-     "end_time": "2023-04-17T15:10:55.171536",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:55.170589",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "Similarly, you can use this pattern when merging (or joining or concatenating) two datasets together."
    ]
@@ -80,22 +47,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "c0d6b6a6",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:55.174794Z",
-     "iopub.status.busy": "2023-04-17T15:10:55.174429Z",
-     "iopub.status.idle": "2023-04-17T15:10:55.181192Z",
-     "shell.execute_reply": "2023-04-17T15:10:55.180318Z"
-    },
-    "papermill": {
-     "duration": 0.012081,
-     "end_time": "2023-04-17T15:10:55.184426",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:55.172345",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class PersonA(Schema):\n",
@@ -118,16 +70,7 @@
   {
    "cell_type": "markdown",
    "id": "b24f0e09",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004025,
-     "end_time": "2023-04-17T15:10:55.190604",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:55.186579",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": []
   }
  ],
@@ -148,18 +91,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.2"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 1.275324,
-   "end_time": "2023-04-17T15:10:55.414433",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "docs/source/subclassing_schemas.ipynb",
-   "output_path": "docs/source/subclassing_schemas.ipynb",
-   "parameters": {},
-   "start_time": "2023-04-17T15:10:54.139109",
-   "version": "2.4.0"
   }
  },
  "nbformat": 4,

--- a/docs/source/transforming_datasets.ipynb
+++ b/docs/source/transforming_datasets.ipynb
@@ -4,16 +4,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "ab6cce16",
-   "metadata": {
-    "papermill": {
-     "duration": 0.010763,
-     "end_time": "2023-04-17T15:10:56.636361",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:56.625598",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Transforming a DataSet to another schema\n",
     "\n",
@@ -24,22 +15,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "44b1c3bb",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:56.650075Z",
-     "iopub.status.busy": "2023-04-17T15:10:56.649564Z",
-     "iopub.status.idle": "2023-04-17T15:10:56.760635Z",
-     "shell.execute_reply": "2023-04-17T15:10:56.759769Z"
-    },
-    "papermill": {
-     "duration": 0.12125,
-     "end_time": "2023-04-17T15:10:56.763587",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:56.642337",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from pyspark.sql.types import IntegerType\n",
@@ -80,16 +56,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "2ba1ded0",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003207,
-     "end_time": "2023-04-17T15:10:56.770753",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:56.767546",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "We can make that quite a bit more condensed:"
    ]
@@ -98,22 +65,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "a08d2a1f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:56.776935Z",
-     "iopub.status.busy": "2023-04-17T15:10:56.776578Z",
-     "iopub.status.idle": "2023-04-17T15:10:56.783441Z",
-     "shell.execute_reply": "2023-04-17T15:10:56.782801Z"
-    },
-    "papermill": {
-     "duration": 0.011824,
-     "end_time": "2023-04-17T15:10:56.785842",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:56.774018",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from typedspark import transform_to_schema\n",
@@ -135,16 +87,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "bb3fb301",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003438,
-     "end_time": "2023-04-17T15:10:56.792707",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:56.789269",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "This function can also be used to just select the subset of columns used in the schema, simply omit the third argument."
    ]
@@ -153,22 +96,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "1e13a30f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:56.800286Z",
-     "iopub.status.busy": "2023-04-17T15:10:56.800015Z",
-     "iopub.status.idle": "2023-04-17T15:10:56.806886Z",
-     "shell.execute_reply": "2023-04-17T15:10:56.806173Z"
-    },
-    "papermill": {
-     "duration": 0.013541,
-     "end_time": "2023-04-17T15:10:56.809302",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:56.795761",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class A(Schema):\n",
@@ -190,40 +118,16 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "98d00a0f",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003052,
-     "end_time": "2023-04-17T15:10:56.815670",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:56.812618",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "The `transformations` dictionary in `transform_to_schema(..., transformations)` requires columns with unique names as keys. The following pattern will throw an exception."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "916f8122",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:10:56.823106Z",
-     "iopub.status.busy": "2023-04-17T15:10:56.822677Z",
-     "iopub.status.idle": "2023-04-17T15:11:03.253329Z",
-     "shell.execute_reply": "2023-04-17T15:11:03.252971Z"
-    },
-    "papermill": {
-     "duration": 6.435576,
-     "end_time": "2023-04-17T15:11:03.254308",
-     "exception": false,
-     "start_time": "2023-04-17T15:10:56.818732",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
@@ -235,22 +139,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "756995ae",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:11:03.257519Z",
-     "iopub.status.busy": "2023-04-17T15:11:03.257399Z",
-     "iopub.status.idle": "2023-04-17T15:11:04.525800Z",
-     "shell.execute_reply": "2023-04-17T15:11:04.525509Z"
-    },
-    "papermill": {
-     "duration": 1.270931,
-     "end_time": "2023-04-17T15:11:04.526677",
-     "exception": false,
-     "start_time": "2023-04-17T15:11:03.255746",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -282,16 +171,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "67b9285c",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001192,
-     "end_time": "2023-04-17T15:11:04.529353",
-     "exception": false,
-     "start_time": "2023-04-17T15:11:04.528161",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "Instead, use one line per column"
    ]
@@ -300,22 +180,7 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "46c8833f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:11:04.532062Z",
-     "iopub.status.busy": "2023-04-17T15:11:04.531954Z",
-     "iopub.status.idle": "2023-04-17T15:11:05.754605Z",
-     "shell.execute_reply": "2023-04-17T15:11:05.754302Z"
-    },
-    "papermill": {
-     "duration": 1.225345,
-     "end_time": "2023-04-17T15:11:05.755754",
-     "exception": false,
-     "start_time": "2023-04-17T15:11:04.530409",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -345,16 +210,7 @@
   {
    "cell_type": "markdown",
    "id": "6546f023",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00115,
-     "end_time": "2023-04-17T15:11:05.758396",
-     "exception": false,
-     "start_time": "2023-04-17T15:11:05.757246",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": []
   }
  ],
@@ -375,18 +231,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.2"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 10.75566,
-   "end_time": "2023-04-17T15:11:06.488335",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "docs/source/transforming_datasets.ipynb",
-   "output_path": "docs/source/transforming_datasets.ipynb",
-   "parameters": {},
-   "start_time": "2023-04-17T15:10:55.732675",
-   "version": "2.4.0"
   }
  },
  "nbformat": 4,

--- a/docs/source/type_checking.ipynb
+++ b/docs/source/type_checking.ipynb
@@ -4,16 +4,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "a6b265df",
-   "metadata": {
-    "papermill": {
-     "duration": 0.01007,
-     "end_time": "2023-04-17T15:11:07.691819",
-     "exception": false,
-     "start_time": "2023-04-17T15:11:07.681749",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Type checking\n",
     "## Runtime\n",
@@ -25,22 +16,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "24a21def",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:11:07.703886Z",
-     "iopub.status.busy": "2023-04-17T15:11:07.703558Z",
-     "iopub.status.idle": "2023-04-17T15:11:14.321034Z",
-     "shell.execute_reply": "2023-04-17T15:11:14.320686Z"
-    },
-    "papermill": {
-     "duration": 6.624652,
-     "end_time": "2023-04-17T15:11:14.322134",
-     "exception": false,
-     "start_time": "2023-04-17T15:11:07.697482",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
@@ -52,22 +28,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "fd37a1d1",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:11:14.325238Z",
-     "iopub.status.busy": "2023-04-17T15:11:14.325103Z",
-     "iopub.status.idle": "2023-04-17T15:11:16.726613Z",
-     "shell.execute_reply": "2023-04-17T15:11:16.726150Z"
-    },
-    "papermill": {
-     "duration": 2.404045,
-     "end_time": "2023-04-17T15:11:16.727595",
-     "exception": false,
-     "start_time": "2023-04-17T15:11:14.323550",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -112,16 +73,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "c27a99fe",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001087,
-     "end_time": "2023-04-17T15:11:16.730118",
-     "exception": false,
-     "start_time": "2023-04-17T15:11:16.729031",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "As a convention, we ignore any columns that start with `__` during this check."
    ]
@@ -130,22 +82,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "b99e82f8",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:11:16.732897Z",
-     "iopub.status.busy": "2023-04-17T15:11:16.732734Z",
-     "iopub.status.idle": "2023-04-17T15:11:16.998965Z",
-     "shell.execute_reply": "2023-04-17T15:11:16.998507Z"
-    },
-    "papermill": {
-     "duration": 0.269038,
-     "end_time": "2023-04-17T15:11:17.000216",
-     "exception": false,
-     "start_time": "2023-04-17T15:11:16.731178",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -182,22 +119,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "baa96cfa",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:11:17.003702Z",
-     "iopub.status.busy": "2023-04-17T15:11:17.003445Z",
-     "iopub.status.idle": "2023-04-17T15:11:17.051320Z",
-     "shell.execute_reply": "2023-04-17T15:11:17.050637Z"
-    },
-    "papermill": {
-     "duration": 0.051377,
-     "end_time": "2023-04-17T15:11:17.053069",
-     "exception": false,
-     "start_time": "2023-04-17T15:11:17.001692",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -226,22 +148,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "71bfc3b9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:11:17.057435Z",
-     "iopub.status.busy": "2023-04-17T15:11:17.057282Z",
-     "iopub.status.idle": "2023-04-17T15:11:17.078811Z",
-     "shell.execute_reply": "2023-04-17T15:11:17.078523Z"
-    },
-    "papermill": {
-     "duration": 0.02505,
-     "end_time": "2023-04-17T15:11:17.079853",
-     "exception": false,
-     "start_time": "2023-04-17T15:11:17.054803",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -272,16 +179,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "357c3f96",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001128,
-     "end_time": "2023-04-17T15:11:17.082488",
-     "exception": false,
-     "start_time": "2023-04-17T15:11:17.081360",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "Assuming your code is run regularly (e.g. through unit tests, scheduled pipelines, etc.), this means you can safely assume a `DataSet[Person]` object that you come across on the master branch indeed follows the indicated schema.\n",
     "\n",
@@ -293,22 +191,7 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "7e34671a",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-04-17T15:11:17.085467Z",
-     "iopub.status.busy": "2023-04-17T15:11:17.085262Z",
-     "iopub.status.idle": "2023-04-17T15:11:17.247254Z",
-     "shell.execute_reply": "2023-04-17T15:11:17.246979Z"
-    },
-    "papermill": {
-     "duration": 0.164637,
-     "end_time": "2023-04-17T15:11:17.248236",
-     "exception": false,
-     "start_time": "2023-04-17T15:11:17.083599",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class Person(Schema):\n",
@@ -375,16 +258,7 @@
    "attachments": {},
    "cell_type": "markdown",
    "id": "30738286",
-   "metadata": {
-    "papermill": {
-     "duration": 0.001216,
-     "end_time": "2023-04-17T15:11:17.250977",
-     "exception": false,
-     "start_time": "2023-04-17T15:11:17.249761",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": []
   }
  ],

--- a/docs/source/type_checking.ipynb
+++ b/docs/source/type_checking.ipynb
@@ -17,13 +17,7 @@
    "execution_count": 1,
    "id": "24a21def",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
     "spark = SparkSession.Builder().config(\"spark.ui.showConsoleProgress\", \"false\").getOrCreate()\n",

--- a/docs/source/type_checking.ipynb
+++ b/docs/source/type_checking.ipynb
@@ -14,10 +14,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "24a21def",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": []
+    }
+   ],
    "source": [
     "from pyspark.sql import SparkSession\n",
     "spark = SparkSession.Builder().config(\"spark.ui.showConsoleProgress\", \"false\").getOrCreate()\n",
@@ -278,19 +284,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 11.189991,
-   "end_time": "2023-04-17T15:11:17.981513",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "docs/source/type_checking.ipynb",
-   "output_path": "docs/source/type_checking.ipynb",
-   "parameters": {},
-   "start_time": "2023-04-17T15:11:06.791522",
-   "version": "2.4.0"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,7 @@ chispa==0.9.2
 # notebooks
 papermill==2.4.0
 jupyter==1.0.0
+nbformat==5.8.0
 # readthedocs
 sphinx==6.1.3
 sphinx-rtd-theme==1.2.0

--- a/typedspark/_utils/load_table.py
+++ b/typedspark/_utils/load_table.py
@@ -63,7 +63,6 @@ def load_table(spark: SparkSession, table_name: str) -> Tuple[DataSet[Schema], T
 
         df, Person = load_table(spark, "path.to.table")
     """
-
     dataframe = spark.table(table_name)
     schema = _create_schema(dataframe.schema)
     dataset = DataSet[schema](dataframe)  # type: ignore


### PR DESCRIPTION
Adding a shell script that runs all notebooks and strips out the metadata, such that in the future diffs will be much more straightforward.