### PR TITLE
Allow for autocomplete of dtype.schema in Databricks

### DIFF
--- a/tests/_schema/test_schema.py
+++ b/tests/_schema/test_schema.py
@@ -169,9 +169,9 @@ def test_dtype_attributes(spark: SparkSession):
                 spark,
                 Values,
                 {
-                    Values.a: [1, 2, 3],
+                    Values.b: ["a", "b", "c"],
                 },
             ).collect(),
         },
     )
-    assert df.filter(ComplexDatatypes.value.dtype.schema.a > 1).count() == 2
+    assert df.filter(ComplexDatatypes.value.dtype.schema.b == "b").count() == 1

--- a/typedspark/_core/datatypes.py
+++ b/typedspark/_core/datatypes.py
@@ -2,8 +2,7 @@
 ``StructType`` in order to allow e.g. for ``ArrayType[StringType]``."""
 from __future__ import annotations
 
-from abc import ABC
-from typing import TYPE_CHECKING, Generic, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Generic, Type, TypeVar
 
 from pyspark.sql.types import DataType
 
@@ -20,11 +19,23 @@ _Precision = TypeVar("_Precision", bound=int)  # pylint: disable=invalid-name
 _Scale = TypeVar("_Scale", bound=int)  # pylint: disable=invalid-name
 
 
-class TypedSparkDataType(DataType, ABC):
-    """Abstract base class for typedspark specific ``DataTypes``."""
+class TypedSparkDataType(DataType):
+    """Base class for typedspark specific ``DataTypes``."""
 
 
-class StructType(Generic[_Schema], TypedSparkDataType):
+class StructTypeMeta(type):
+    """Initializes schema as None.
+
+    This allows for auto-complete in Databricks notebooks (uninitialized variables don't
+    show up in auto-complete there).
+    """
+
+    def __new__(cls, name: str, bases: Any, dct: Dict[str, Any]):
+        dct["schema"] = None
+        return super().__new__(cls, name, bases, dct)
+
+
+class StructType(Generic[_Schema], TypedSparkDataType, metaclass=StructTypeMeta):
     """Allows for type annotations such as:
 
     .. code-block:: python

--- a/typedspark/_core/datatypes.py
+++ b/typedspark/_core/datatypes.py
@@ -24,7 +24,7 @@ class TypedSparkDataType(DataType):
 
 
 class StructTypeMeta(type):
-    """Initializes schema as None.
+    """Initializes the schema attribute as None.
 
     This allows for auto-complete in Databricks notebooks (uninitialized variables don't
     show up in auto-complete there).


### PR DESCRIPTION
Consider the following example:

```python
from pyspark.sql import SparkSession
from pyspark.sql.types import IntegerType
from typedspark import Column, Schema
from typedspark._core.datatypes import StructType

spark = SparkSession.builder.getOrCreate()

class A(Schema):
    a: Column[IntegerType]

class B(Schema):
    a: Column[IntegerType]
    b: Column[StructType[A]]
```

Suppose we create a `DataSet` using this schema, save it as a table, and then load it using `table, Table = load_table(...)`. On Databricks, the inferred schema `Table` then wouldn't auto-complete `Table.b.dtype.schema`. This PR fixes that bug.