### PR TITLE
Add option for schema name in the load_table function

### DIFF
--- a/docs/source/autocomplete_in_databricks.ipynb
+++ b/docs/source/autocomplete_in_databricks.ipynb
@@ -13,20 +13,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "87752202",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Setting default log level to \"WARN\".\n",
-      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n",
-      "23/06/28 13:42:32 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from pyspark.sql import SparkSession\n",
     "spark = SparkSession.Builder().config(\"spark.ui.showConsoleProgress\", \"false\").getOrCreate()\n",
@@ -195,14 +185,6 @@
     "df, Person = load_table(spark, \"person_table\", schema_name=\"Person\")\n",
     "Person"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9999785a",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/source/autocomplete_in_databricks.ipynb
+++ b/docs/source/autocomplete_in_databricks.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c3322756",
    "metadata": {},
@@ -17,7 +16,17 @@
    "execution_count": 1,
    "id": "87752202",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Setting default log level to \"WARN\".\n",
+      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n",
+      "23/06/28 13:42:32 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
+     ]
+    }
+   ],
    "source": [
     "from pyspark.sql import SparkSession\n",
     "spark = SparkSession.Builder().config(\"spark.ui.showConsoleProgress\", \"false\").getOrCreate()\n",
@@ -47,7 +56,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "4bd96763",
    "metadata": {},
@@ -68,7 +76,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "65c183c1",
    "metadata": {},
@@ -105,7 +112,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "08f247d1",
    "metadata": {},
@@ -117,14 +123,91 @@
   },
   {
    "cell_type": "markdown",
+   "id": "77feef54",
+   "metadata": {},
+   "source": [
+    "Next to using the Schema in your next query, there can also be reasons you want the code representation of the Schema."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "517e5481",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "from pyspark.sql.types import LongType, StringType\n",
+       "\n",
+       "from typedspark import Column, Schema\n",
+       "\n",
+       "\n",
+       "class DynamicallyLoadedSchema(Schema):\n",
+       "    name: Column[StringType]\n",
+       "    age: Column[LongType]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Person"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "534ee9d9",
    "metadata": {},
+   "source": [
+    "To use this to define the schema in your codebase, the Schema name needs to be changed. One can do this by defining the `schema_name` in the `load_table` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "28d60ba8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "from pyspark.sql.types import LongType, StringType\n",
+       "\n",
+       "from typedspark import Column, Schema\n",
+       "\n",
+       "\n",
+       "class Person(Schema):\n",
+       "    name: Column[StringType]\n",
+       "    age: Column[LongType]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df, Person = load_table(spark, \"person_table\", schema_name=\"Person\")\n",
+    "Person"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9999785a",
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "typedspark",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -138,7 +221,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/docs/source/autocomplete_in_databricks.ipynb
+++ b/docs/source/autocomplete_in_databricks.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "87752202",
    "metadata": {},
    "outputs": [],
@@ -124,26 +124,7 @@
    "execution_count": 5,
    "id": "517e5481",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\n",
-       "from pyspark.sql.types import LongType, StringType\n",
-       "\n",
-       "from typedspark import Column, Schema\n",
-       "\n",
-       "\n",
-       "class DynamicallyLoadedSchema(Schema):\n",
-       "    name: Column[StringType]\n",
-       "    age: Column[LongType]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Person"
    ]
@@ -161,26 +142,7 @@
    "execution_count": 6,
    "id": "28d60ba8",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\n",
-       "from pyspark.sql.types import LongType, StringType\n",
-       "\n",
-       "from typedspark import Column, Schema\n",
-       "\n",
-       "\n",
-       "class Person(Schema):\n",
-       "    name: Column[StringType]\n",
-       "    age: Column[LongType]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df, Person = load_table(spark, \"person_table\", schema_name=\"Person\")\n",
     "Person"
@@ -203,7 +165,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/tests/_utils/test_load_table.py
+++ b/tests/_utils/test_load_table.py
@@ -32,3 +32,15 @@ def test_load_table(spark: SparkSession) -> None:
 
     assert_df_equality(df, df_loaded)
     assert schema.get_structtype() == A.get_structtype()
+    assert schema.get_schema_name() != "A"
+
+
+def test_load_table_with_schema_name(spark: SparkSession) -> None:
+    df = create_empty_dataset(spark, A)
+    df.createOrReplaceTempView("temp")
+
+    df_loaded, schema = load_table(spark, "temp", schema_name="A")
+
+    assert_df_equality(df, df_loaded)
+    assert schema.get_structtype() == A.get_structtype()
+    assert schema.get_schema_name() == "A"

--- a/typedspark/_utils/load_table.py
+++ b/typedspark/_utils/load_table.py
@@ -1,6 +1,6 @@
 """Functions for loading `DataSet` and `Schema` in notebooks."""
 
-from typing import Dict, Tuple, Type, Optional
+from typing import Dict, Optional, Tuple, Type
 
 from pyspark.sql import SparkSession
 from pyspark.sql.types import ArrayType as SparkArrayType
@@ -55,7 +55,9 @@ def _extract_data_type(dtype: DataType) -> Type[DataType]:
     return type(dtype)
 
 
-def load_table(spark: SparkSession, table_name: str, schema_name: Optional[str] = None) -> Tuple[DataSet[Schema], Type[Schema]]:
+def load_table(
+    spark: SparkSession, table_name: str, schema_name: Optional[str] = None
+) -> Tuple[DataSet[Schema], Type[Schema]]:
     """This function loads a ``DataSet``, along with its inferred ``Schema``,
     in a notebook.
 


### PR DESCRIPTION
To use the schema returned by `load_table` as defintion in your code schemas, the schema_name needs to be defined. This PR adds the option to this function.