### PR TITLE
fix decimaltype schema issues

### DIFF
--- a/tests/_utils/test_load_table.py
+++ b/tests/_utils/test_load_table.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from chispa.dataframe_comparer import assert_df_equality  # type: ignore
 from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType
@@ -5,6 +7,7 @@ from pyspark.sql.types import IntegerType
 from typedspark import (
     ArrayType,
     Column,
+    DecimalType,
     MapType,
     Schema,
     StructType,
@@ -22,6 +25,7 @@ class A(Schema):
     b: Column[ArrayType[IntegerType]]
     c: Column[ArrayType[MapType[IntegerType, IntegerType]]]
     d: Column[StructType[SubSchema]]
+    e: Column[DecimalType[Literal[7], Literal[2]]]
 
 
 def test_load_table(spark: SparkSession) -> None:

--- a/typedspark/_utils/load_table.py
+++ b/typedspark/_utils/load_table.py
@@ -1,16 +1,17 @@
 """Functions for loading `DataSet` and `Schema` in notebooks."""
 
-from typing import Dict, Optional, Tuple, Type
+from typing import Dict, Literal, Optional, Tuple, Type
 
 from pyspark.sql import SparkSession
 from pyspark.sql.types import ArrayType as SparkArrayType
 from pyspark.sql.types import DataType
+from pyspark.sql.types import DecimalType as SparkDecimalType
 from pyspark.sql.types import MapType as SparkMapType
 from pyspark.sql.types import StructType as SparkStructType
 
 from typedspark._core.column import Column
 from typedspark._core.dataset import DataSet
-from typedspark._core.datatypes import ArrayType, MapType, StructType
+from typedspark._core.datatypes import ArrayType, DecimalType, MapType, StructType
 from typedspark._schema.schema import MetaSchema, Schema
 from typedspark._utils.register_schema_to_dataset import register_schema_to_dataset
 
@@ -51,6 +52,11 @@ def _extract_data_type(dtype: DataType) -> Type[DataType]:
     if isinstance(dtype, SparkStructType):
         subschema = _create_schema(dtype)
         return StructType[subschema]  # type: ignore
+
+    if isinstance(dtype, SparkDecimalType):
+        precision = dtype.precision
+        scale = dtype.scale
+        return DecimalType[Literal[precision], Literal[scale]]  # type: ignore
 
     return type(dtype)
 


### PR DESCRIPTION
before this PR: TypeError with occur when loading tables with DecimalType column with different precision and scale than (10,0)
after this PR: it works 🐬 