### PR TITLE
Include docstrings in schemas

### DIFF
--- a/tests/_schema/test_get_schema_definition.py
+++ b/tests/_schema/test_get_schema_definition.py
@@ -1,16 +1,16 @@
 from typing import Annotated
 
-from pyspark.sql import Column
 from pyspark.sql.types import IntegerType, StringType
 
-from typedspark._core.datatypes import DayTimeIntervalType
-from typedspark._core.literaltype import IntervalType
+from typedspark import Column, DayTimeIntervalType, IntervalType, Schema
+
+# from typedspark._core.datatypes import DayTimeIntervalType
+# from typedspark._core.literaltype import IntervalType
 from typedspark._schema.get_schema_definition import _replace_literal, _replace_literals
-from typedspark._schema.schema import Schema
 
 
 class A(Schema):
-    """ "This is a docstring for A."""
+    """This is a docstring for A."""
 
     a: Annotated[Column[IntegerType], "Some column"]
     b: Column[StringType]
@@ -41,15 +41,17 @@ def test_replace_literals():
 
 def test_get_schema_definition_as_string():
     result = A.get_schema_definition_as_string(include_documentation=True)
-    expected = '''
-    from pyspark.sql.types import IntegerType, StringType
+    expected = '''from typing import Annotated
 
-    from typedspark import Column, Schema
+from pyspark.sql.types import IntegerType, StringType
+
+from typedspark import Column, ColumnMeta, Schema
 
 
-    class A(Schema):
+class A(Schema):
     """This is a docstring for A."""
-        a: Annotated[Column[IntegerType], ColumnMeta(comment="Some column")]
-        b: Annotated[Column[StringType], ColumnMeta(comment="")]"'
-    '''
+
+    a: Annotated[Column[IntegerType], ColumnMeta(comment="Some column")]
+    b: Annotated[Column[StringType], ColumnMeta(comment="")]
+'''
     assert result == expected

--- a/tests/_schema/test_get_schema_definition.py
+++ b/tests/_schema/test_get_schema_definition.py
@@ -3,7 +3,6 @@ from typing import Annotated
 from pyspark.sql.types import IntegerType, StringType
 
 from typedspark import Column, DayTimeIntervalType, IntervalType, Schema
-
 from typedspark._schema.get_schema_definition import _replace_literal, _replace_literals
 
 

--- a/tests/_schema/test_get_schema_definition.py
+++ b/tests/_schema/test_get_schema_definition.py
@@ -4,8 +4,6 @@ from pyspark.sql.types import IntegerType, StringType
 
 from typedspark import Column, DayTimeIntervalType, IntervalType, Schema
 
-# from typedspark._core.datatypes import DayTimeIntervalType
-# from typedspark._core.literaltype import IntervalType
 from typedspark._schema.get_schema_definition import _replace_literal, _replace_literals
 
 

--- a/tests/_schema/test_get_schema_definition.py
+++ b/tests/_schema/test_get_schema_definition.py
@@ -1,7 +1,8 @@
 from typing import Annotated
+
 from pyspark.sql import Column
 from pyspark.sql.types import IntegerType, StringType
-from typedspark._core.column_meta import ColumnMeta
+
 from typedspark._core.datatypes import DayTimeIntervalType
 from typedspark._core.literaltype import IntervalType
 from typedspark._schema.get_schema_definition import _replace_literal, _replace_literals
@@ -9,7 +10,8 @@ from typedspark._schema.schema import Schema
 
 
 class A(Schema):
-    """"This is a docstring for A."""
+    """ "This is a docstring for A."""
+
     a: Annotated[Column[IntegerType], "Some column"]
     b: Column[StringType]
 
@@ -37,15 +39,9 @@ def test_replace_literals():
     assert result == expected
 
 
-def test_get_schema_definition_as_string(
-        # schema: Type[Schema],
-        # include_documentation: bool,
-        # generate_imports: bool,
-        # add_subschemas: bool,
-        # class_name: str = "MyNewSchema",
-    ):
+def test_get_schema_definition_as_string():
     result = A.get_schema_definition_as_string(include_documentation=True)
-    expected = ('''
+    expected = '''
     from pyspark.sql.types import IntegerType, StringType
 
     from typedspark import Column, Schema
@@ -55,5 +51,5 @@ def test_get_schema_definition_as_string(
     """This is a docstring for A."""
         a: Annotated[Column[IntegerType], ColumnMeta(comment="Some column")]
         b: Annotated[Column[StringType], ColumnMeta(comment="")]"'
-    ''')
+    '''
     assert result == expected

--- a/tests/_schema/test_get_schema_definition.py
+++ b/tests/_schema/test_get_schema_definition.py
@@ -1,6 +1,17 @@
+from typing import Annotated
+from pyspark.sql import Column
+from pyspark.sql.types import IntegerType, StringType
+from typedspark._core.column_meta import ColumnMeta
 from typedspark._core.datatypes import DayTimeIntervalType
 from typedspark._core.literaltype import IntervalType
 from typedspark._schema.get_schema_definition import _replace_literal, _replace_literals
+from typedspark._schema.schema import Schema
+
+
+class A(Schema):
+    """"This is a docstring for A."""
+    a: Annotated[Column[IntegerType], "Some column"]
+    b: Column[StringType]
 
 
 def test_replace_literal():
@@ -23,4 +34,26 @@ def test_replace_literals():
     )
     expected = "DayTimeIntervalType[IntervalType.DAY, IntervalType.HOUR]"
 
+    assert result == expected
+
+
+def test_get_schema_definition_as_string(
+        # schema: Type[Schema],
+        # include_documentation: bool,
+        # generate_imports: bool,
+        # add_subschemas: bool,
+        # class_name: str = "MyNewSchema",
+    ):
+    result = A.get_schema_definition_as_string(include_documentation=True)
+    expected = ('''
+    from pyspark.sql.types import IntegerType, StringType
+
+    from typedspark import Column, Schema
+
+
+    class A(Schema):
+    """This is a docstring for A."""
+        a: Annotated[Column[IntegerType], ColumnMeta(comment="Some column")]
+        b: Annotated[Column[StringType], ColumnMeta(comment="")]"'
+    ''')
     assert result == expected

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -60,7 +60,7 @@ def _build_schema_definition_string(
         )
         typehint = _replace_literals(
             typehint, replace_literals_in=DayTimeIntervalType, replace_literals_by=IntervalType
-        ) 
+        )
         if include_documentation:
             if hasattr(schema.__annotations__[k], "__metadata__"):
                 print("attribute exists")

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -62,8 +62,11 @@ def _build_schema_definition_string(
             typehint, replace_literals_in=DayTimeIntervalType, replace_literals_by=IntervalType
         )
         if include_documentation:
-            if hasattr(schema.__annotations__[k], "__metadata__"):
-                if schema.__annotations__[k].__metadata__ is not None:
+            if k in schema.__annotations__:
+                if (
+                    hasattr(schema.__annotations__[k], "__metadata__")
+                    and schema.__annotations__[k].__metadata__ is not None
+                ):
                     lines += (
                         f"    {k}: Annotated[{typehint}, "
                         + f'ColumnMeta(comment="{schema.__annotations__[k].__metadata__[0]}")]\n'

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -66,7 +66,7 @@ def _build_schema_definition_string(
                 print("attribute exists")
                 if schema.__annotations__[k].__metadata__ is not None:
                     lines += (
-                        f'    {k}: Annotated[{typehint}, '
+                        f"    {k}: Annotated[{typehint}, "
                         + f'ColumnMeta(comment="{schema.__annotations__[k].__metadata__[0]}")]\n'
                     )
             else:

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -71,10 +71,10 @@ def _build_schema_definition_string(
                         f"    {k}: Annotated[{typehint}, "
                         + f'ColumnMeta(comment="{schema.__annotations__[k].__metadata__[0]}")]\n'
                     )
+                else:
+                    lines += f'    {k}: Annotated[{typehint}, ColumnMeta(comment="")]\n'
             else:
-                lines += f'    {k}: Annotated[{typehint}, ColumnMeta(comment="")]\n'
-        else:
-            lines += f"    {k}: {typehint}\n"
+                lines += f"    {k}: {typehint}\n"
 
     if add_subschemas:
         lines += _add_subschemas(schema, add_subschemas, include_documentation)

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -63,7 +63,6 @@ def _build_schema_definition_string(
         )
         if include_documentation:
             if hasattr(schema.__annotations__[k], "__metadata__"):
-                print("attribute exists")
                 if schema.__annotations__[k].__metadata__ is not None:
                     lines += (
                         f"    {k}: Annotated[{typehint}, "

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -44,7 +44,10 @@ def _build_schema_definition_string(
     """Return the code for a given ``Schema`` as a string."""
     lines = f"class {class_name}(Schema):\n"
     if include_documentation:
-        lines += '    """Add documentation here."""\n\n'
+        if schema.get_docstring() is not None:
+            lines += f'    """{schema.get_docstring()}"""\n\n'
+        else:
+            lines += '    """Add documentation here."""\n\n'
 
     for k, val in get_type_hints(schema).items():
         typehint = (
@@ -57,9 +60,14 @@ def _build_schema_definition_string(
         )
         typehint = _replace_literals(
             typehint, replace_literals_in=DayTimeIntervalType, replace_literals_by=IntervalType
-        )
+        ) 
         if include_documentation:
-            lines += f'    {k}: Annotated[{typehint}, ColumnMeta(comment="")]\n'
+            if hasattr(schema.__annotations__[k], "__metadata__"):
+                print("attribute exists")
+                if schema.__annotations__[k].__metadata__ is not None:
+                    lines += f'    {k}: Annotated[{typehint}, ColumnMeta(comment="{schema.__annotations__[k].__metadata__[0]}")]\n'
+            else:
+                lines += f'    {k}: Annotated[{typehint}, ColumnMeta(comment="")]\n'
         else:
             lines += f"    {k}: {typehint}\n"
 

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -49,9 +49,9 @@ def _build_schema_definition_string(
         else:
             lines += '    """Add documentation here."""\n\n'
 
-    for k, val in get_type_hints(schema).items():
+    for col_name, col in get_type_hints(schema).items():
         typehint = (
-            str(val)
+            str(col)
             .replace("typedspark._core.column.", "")
             .replace("typedspark._core.datatypes.", "")
             .replace("typedspark._schema.schema.", "")
@@ -62,19 +62,19 @@ def _build_schema_definition_string(
             typehint, replace_literals_in=DayTimeIntervalType, replace_literals_by=IntervalType
         )
         if include_documentation:
-            if k in schema.__annotations__:
+            if col_name in schema.__annotations__:
                 if (
-                    hasattr(schema.__annotations__[k], "__metadata__")
-                    and schema.__annotations__[k].__metadata__ is not None
+                    hasattr(schema.__annotations__[col_name], "__metadata__")
+                    and schema.__annotations__[col_name].__metadata__ is not None
                 ):
                     lines += (
-                        f"    {k}: Annotated[{typehint}, "
-                        + f'ColumnMeta(comment="{schema.__annotations__[k].__metadata__[0]}")]\n'
+                        f"    {col_name}: Annotated[{typehint}, "
+                        + f'ColumnMeta(comment="{schema.__annotations__[col_name].__metadata__[0]}")]\n'
                     )
                 else:
-                    lines += f'    {k}: Annotated[{typehint}, ColumnMeta(comment="")]\n'
+                    lines += f'    {col_name}: Annotated[{typehint}, ColumnMeta(comment="")]\n'
         else:
-            lines += f"    {k}: {typehint}\n"
+            lines += f"    {col_name}: {typehint}\n"
 
     if add_subschemas:
         lines += _add_subschemas(schema, add_subschemas, include_documentation)

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -36,6 +36,7 @@ def get_schema_definition_as_string(
 
 
 def _get_comment(schema: Type[Schema], col_name: str) -> str:
+    """Return the comment of a given column."""
     if (
         hasattr(schema.__annotations__[col_name], "__metadata__")
         and schema.__annotations__[col_name].__metadata__ is not None

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -68,15 +68,14 @@ def _build_schema_definition_string(
                     hasattr(schema.__annotations__[col_name], "__metadata__")
                     and schema.__annotations__[col_name].__metadata__ is not None
                 ):
-                    comment == (
-                        col_annotated_start
-                        + f'ColumnMeta(comment="{schema.__annotations__[col_name].__metadata__[0]}")]\n'
-                    )
+                    comment = schema.__annotations__[col_name].__metadata__[0]
                 else:
-                    comment = col_annotated_start + 'ColumnMeta(comment="")]\n'
+                    comment = ""
+
+                lines += f'{col_annotated_start}ColumnMeta(comment="{comment}")]\n'
         else:
-            comment = f"    {col_name}: {typehint}\n"
-        lines += comment
+            lines += f"    {col_name}: {typehint}\n"
+
     if add_subschemas:
         lines += _add_subschemas(schema, add_subschemas, include_documentation)
 

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -65,7 +65,8 @@ def _build_schema_definition_string(
             if hasattr(schema.__annotations__[k], "__metadata__"):
                 print("attribute exists")
                 if schema.__annotations__[k].__metadata__ is not None:
-                    lines += f'    {k}: Annotated[{typehint}, ColumnMeta(comment="{schema.__annotations__[k].__metadata__[0]}")]\n'
+                    lines += f'    {k}: Annotated[{typehint}, '
+                    + 'ColumnMeta(comment="{schema.__annotations__[k].__metadata__[0]}")]\n'
             else:
                 lines += f'    {k}: Annotated[{typehint}, ColumnMeta(comment="")]\n'
         else:

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -49,9 +49,9 @@ def _build_schema_definition_string(
         else:
             lines += '    """Add documentation here."""\n\n'
 
-    for col_name, col in get_type_hints(schema).items():
+    for col_name, col_object in get_type_hints(schema).items():
         typehint = (
-            str(col)
+            str(col_object)
             .replace("typedspark._core.column.", "")
             .replace("typedspark._core.datatypes.", "")
             .replace("typedspark._schema.schema.", "")
@@ -62,17 +62,18 @@ def _build_schema_definition_string(
             typehint, replace_literals_in=DayTimeIntervalType, replace_literals_by=IntervalType
         )
         if include_documentation:
+            col_annotated_start = f"    {col_name}: Annotated[{typehint}, "
             if col_name in schema.__annotations__:
                 if (
                     hasattr(schema.__annotations__[col_name], "__metadata__")
                     and schema.__annotations__[col_name].__metadata__ is not None
                 ):
                     lines += (
-                        f"    {col_name}: Annotated[{typehint}, "
+                        col_annotated_start
                         + f'ColumnMeta(comment="{schema.__annotations__[col_name].__metadata__[0]}")]\n'
                     )
                 else:
-                    lines += f'    {col_name}: Annotated[{typehint}, ColumnMeta(comment="")]\n'
+                    lines += col_annotated_start + 'ColumnMeta(comment="")]\n'
         else:
             lines += f"    {col_name}: {typehint}\n"
 

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -68,15 +68,15 @@ def _build_schema_definition_string(
                     hasattr(schema.__annotations__[col_name], "__metadata__")
                     and schema.__annotations__[col_name].__metadata__ is not None
                 ):
-                    lines += (
+                    comment == (
                         col_annotated_start
                         + f'ColumnMeta(comment="{schema.__annotations__[col_name].__metadata__[0]}")]\n'
                     )
                 else:
-                    lines += col_annotated_start + 'ColumnMeta(comment="")]\n'
+                    comment = col_annotated_start + 'ColumnMeta(comment="")]\n'
         else:
-            lines += f"    {col_name}: {typehint}\n"
-
+            comment = f"    {col_name}: {typehint}\n"
+        lines += comment
     if add_subschemas:
         lines += _add_subschemas(schema, add_subschemas, include_documentation)
 

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -65,8 +65,10 @@ def _build_schema_definition_string(
             if hasattr(schema.__annotations__[k], "__metadata__"):
                 print("attribute exists")
                 if schema.__annotations__[k].__metadata__ is not None:
-                    lines += f'    {k}: Annotated[{typehint}, '
-                    + 'ColumnMeta(comment="{schema.__annotations__[k].__metadata__[0]}")]\n'
+                    lines += (
+                        f'    {k}: Annotated[{typehint}, '
+                        + f'ColumnMeta(comment="{schema.__annotations__[k].__metadata__[0]}")]\n'
+                    )
             else:
                 lines += f'    {k}: Annotated[{typehint}, ColumnMeta(comment="")]\n'
         else:

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -35,6 +35,17 @@ def get_schema_definition_as_string(
     return imports + schema_string
 
 
+def _get_comment(schema: Type[Schema], col_name: str) -> str:
+    if (
+        hasattr(schema.__annotations__[col_name], "__metadata__")
+        and schema.__annotations__[col_name].__metadata__ is not None
+    ):
+        comment = schema.__annotations__[col_name].__metadata__[0]
+    else:
+        comment = ""
+    return comment
+
+
 def _build_schema_definition_string(
     schema: Type[Schema],
     include_documentation: bool,
@@ -64,14 +75,7 @@ def _build_schema_definition_string(
         if include_documentation:
             col_annotated_start = f"    {col_name}: Annotated[{typehint}, "
             if col_name in schema.__annotations__:
-                if (
-                    hasattr(schema.__annotations__[col_name], "__metadata__")
-                    and schema.__annotations__[col_name].__metadata__ is not None
-                ):
-                    comment = schema.__annotations__[col_name].__metadata__[0]
-                else:
-                    comment = ""
-
+                comment = _get_comment(schema, col_name)
                 lines += f'{col_annotated_start}ColumnMeta(comment="{comment}")]\n'
         else:
             lines += f"    {col_name}: {typehint}\n"

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -73,8 +73,8 @@ def _build_schema_definition_string(
                     )
                 else:
                     lines += f'    {k}: Annotated[{typehint}, ColumnMeta(comment="")]\n'
-            else:
-                lines += f"    {k}: {typehint}\n"
+        else:
+            lines += f"    {k}: {typehint}\n"
 
     if add_subschemas:
         lines += _add_subschemas(schema, add_subschemas, include_documentation)

--- a/typedspark/_schema/schema.py
+++ b/typedspark/_schema/schema.py
@@ -1,10 +1,10 @@
 """Module containing classes and functions related to TypedSpark Schemas."""
 import inspect
 import re
-from typing import Any, Dict, List, Optional, Type, Union, get_args, get_type_hints
+from typing import Annotated, Any, Dict, List, Optional, Type, Union, get_args, get_type_hints
 
 from pyspark.sql import DataFrame
-from pyspark.sql.types import DataType, StructType
+from pyspark.sql.types import DataType, IntegerType, StructType
 
 from typedspark._core.column import Column
 from typedspark._schema.dlt_kwargs import DltKwargs
@@ -49,9 +49,9 @@ class MetaSchema(type):
     def __repr__(cls) -> str:
         return f"\n{str(cls)}"
 
-    def __str__(cls, include_documentation=False) -> str:
+    def __str__(cls) -> str:
         return cls.get_schema_definition_as_string(
-            include_documentation=include_documentation, add_subschemas=False
+            add_subschemas=False
         )
 
     def __getattribute__(cls, name: str) -> Any:
@@ -190,3 +190,15 @@ class Schema(metaclass=MetaSchema):
     # to not add a docstring to the Schema class (otherwise the Schema
     # docstring would be added to any schema without a docstring).
     pass
+
+
+new_schema = type("SomeModel", (Schema,), {})
+cols = {
+    "a": Annotated[Column[IntegerType], "Some column"], 
+    "b": Column[IntegerType]
+}
+new_schema.__annotations__ = cols
+new_schema.__doc__ = "This is a docstring for SomeModel."
+
+print(new_schema.get_schema_definition_as_string(include_documentation=True))
+print(new_schema)

--- a/typedspark/_schema/schema.py
+++ b/typedspark/_schema/schema.py
@@ -51,7 +51,7 @@ class MetaSchema(type):
 
     def __str__(cls, include_documentation=False) -> str:
         return cls.get_schema_definition_as_string(
-            include_documentation=include_documentation, add_subschemas=False
+            include_documentation=include_documentation, add_subschemas=False 
         )
 
     def __getattribute__(cls, name: str) -> Any:

--- a/typedspark/_schema/schema.py
+++ b/typedspark/_schema/schema.py
@@ -51,7 +51,7 @@ class MetaSchema(type):
 
     def __str__(cls, include_documentation=False) -> str:
         return cls.get_schema_definition_as_string(
-            include_documentation=include_documentation, add_subschemas=False 
+            include_documentation=include_documentation, add_subschemas=False
         )
 
     def __getattribute__(cls, name: str) -> Any:

--- a/typedspark/_schema/schema.py
+++ b/typedspark/_schema/schema.py
@@ -50,7 +50,7 @@ class MetaSchema(type):
         return f"\n{str(cls)}"
 
     def __str__(cls) -> str:
-        return cls.get_schema_definition_as_string(add_subschemas=False)
+        return cls.get_schema_definition_as_string(include_documentation=True, add_subschemas=False)
 
     def __getattribute__(cls, name: str) -> Any:
         """Python base function that gets attributes.

--- a/typedspark/_schema/schema.py
+++ b/typedspark/_schema/schema.py
@@ -49,8 +49,8 @@ class MetaSchema(type):
     def __repr__(cls) -> str:
         return f"\n{str(cls)}"
 
-    def __str__(cls) -> str:
-        return cls.get_schema_definition_as_string(include_documentation=True, add_subschemas=False)
+    def __str__(cls, include_documentation=False) -> str:
+        return cls.get_schema_definition_as_string(include_documentation=include_documentation, add_subschemas=False)
 
     def __getattribute__(cls, name: str) -> Any:
         """Python base function that gets attributes.

--- a/typedspark/_schema/schema.py
+++ b/typedspark/_schema/schema.py
@@ -50,7 +50,9 @@ class MetaSchema(type):
         return f"\n{str(cls)}"
 
     def __str__(cls, include_documentation=False) -> str:
-        return cls.get_schema_definition_as_string(include_documentation=include_documentation, add_subschemas=False)
+        return cls.get_schema_definition_as_string(
+            include_documentation=include_documentation, add_subschemas=False
+        )
 
     def __getattribute__(cls, name: str) -> Any:
         """Python base function that gets attributes.

--- a/typedspark/_schema/schema.py
+++ b/typedspark/_schema/schema.py
@@ -50,9 +50,7 @@ class MetaSchema(type):
         return f"\n{str(cls)}"
 
     def __str__(cls) -> str:
-        return cls.get_schema_definition_as_string(
-            add_subschemas=False
-        )
+        return cls.get_schema_definition_as_string(add_subschemas=False)
 
     def __getattribute__(cls, name: str) -> Any:
         """Python base function that gets attributes.
@@ -193,10 +191,7 @@ class Schema(metaclass=MetaSchema):
 
 
 new_schema = type("SomeModel", (Schema,), {})
-cols = {
-    "a": Annotated[Column[IntegerType], "Some column"], 
-    "b": Column[IntegerType]
-}
+cols = {"a": Annotated[Column[IntegerType], "Some column"], "b": Column[IntegerType]}
 new_schema.__annotations__ = cols
 new_schema.__doc__ = "This is a docstring for SomeModel."
 

--- a/typedspark/_schema/schema.py
+++ b/typedspark/_schema/schema.py
@@ -1,10 +1,10 @@
 """Module containing classes and functions related to TypedSpark Schemas."""
 import inspect
 import re
-from typing import Annotated, Any, Dict, List, Optional, Type, Union, get_args, get_type_hints
+from typing import Any, Dict, List, Optional, Type, Union, get_args, get_type_hints
 
 from pyspark.sql import DataFrame
-from pyspark.sql.types import DataType, IntegerType, StructType
+from pyspark.sql.types import DataType, StructType
 
 from typedspark._core.column import Column
 from typedspark._schema.dlt_kwargs import DltKwargs
@@ -188,12 +188,3 @@ class Schema(metaclass=MetaSchema):
     # to not add a docstring to the Schema class (otherwise the Schema
     # docstring would be added to any schema without a docstring).
     pass
-
-
-new_schema = type("SomeModel", (Schema,), {})
-cols = {"a": Annotated[Column[IntegerType], "Some column"], "b": Column[IntegerType]}
-new_schema.__annotations__ = cols
-new_schema.__doc__ = "This is a docstring for SomeModel."
-
-print(new_schema.get_schema_definition_as_string(include_documentation=True))
-print(new_schema)


### PR DESCRIPTION
Fixes missing docstrings and comments when printing schema as string.

(Please don't mind the 35345743 commits, there aren't that many changes 😄 I just couldn't get the tests running locally)