### PR TITLE
Support self-joins in typedspark

### DIFF
--- a/docs/source/column_ambiguity.ipynb
+++ b/docs/source/column_ambiguity.ipynb
@@ -250,7 +250,7 @@
     }
    ],
    "source": [
-    "from typedspark._utils.register_schema_to_dataset import register_schema_to_dataset_with_alias\n",
+    "from typedspark import register_schema_to_dataset_with_alias\n",
     "\n",
     "\n",
     "df = create_partially_filled_dataset(\n",

--- a/docs/source/column_ambiguity.ipynb
+++ b/docs/source/column_ambiguity.ipynb
@@ -116,7 +116,7 @@
    "source": [
     "## Ambiguous columns and transform_to_schema()\n",
     "\n",
-    "It is often a good idea to drop the ambiguous column, for example:"
+    "When you use `transform_to_schema()` in a setting with ambiguous columns, you may run into the following error:"
    ]
   },
   {
@@ -221,6 +221,57 @@
   {
    "cell_type": "markdown",
    "id": "675b4dfc",
+   "metadata": {},
+   "source": [
+    "## Self-joins\n",
+    "\n",
+    "When dealing with self-joins, running `register_dataset_to_schema()` is not enough. Instead, we'll need `register_dataset_to_schema_with_alias()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8ea83b65",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---+-------+---+---+-------+---+\n",
+      "| id|   name|age| id|   name|age|\n",
+      "+---+-------+---+---+-------+---+\n",
+      "|  1|  Alice| 20|  1|  Alice| 20|\n",
+      "|  2|    Bob| 30|  2|    Bob| 30|\n",
+      "|  3|Charlie| 40|  3|Charlie| 40|\n",
+      "+---+-------+---+---+-------+---+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from typedspark._utils.register_schema_to_dataset import register_schema_to_dataset_with_alias\n",
+    "\n",
+    "\n",
+    "df = create_partially_filled_dataset(\n",
+    "    spark,\n",
+    "    Person,\n",
+    "    {\n",
+    "        Person.id: [1, 2, 3],\n",
+    "        Person.name: [\"Alice\", \"Bob\", \"Charlie\"],\n",
+    "        Person.age: [20, 30, 40],\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "df_a, person_a = register_schema_to_dataset_with_alias(df, Person, alias=\"a\")\n",
+    "df_b, person_b = register_schema_to_dataset_with_alias(df, Person, alias=\"b\")\n",
+    "\n",
+    "df_a.join(df_b, person_a.id == person_b.id).show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a8dcdd1",
    "metadata": {},
    "source": []
   }

--- a/tests/_utils/test_register_schema_to_dataset.py
+++ b/tests/_utils/test_register_schema_to_dataset.py
@@ -1,19 +1,38 @@
 import pytest
+from chispa.dataframe_comparer import assert_df_equality  # type: ignore
 from pyspark.errors import AnalysisException
 from pyspark.sql import SparkSession
-from pyspark.sql.types import IntegerType
+from pyspark.sql.types import IntegerType, StringType
 
-from typedspark import Column, Schema, create_partially_filled_dataset, register_schema_to_dataset
+from typedspark import (
+    Column,
+    Schema,
+    StructType,
+    create_partially_filled_dataset,
+    register_schema_to_dataset,
+)
+from typedspark._utils.register_schema_to_dataset import register_schema_to_dataset_with_alias
+
+
+class Pets(Schema):
+    name: Column[StringType]
+    age: Column[IntegerType]
 
 
 class Person(Schema):
     a: Column[IntegerType]
     b: Column[IntegerType]
+    pets: Column[StructType[Pets]]
 
 
 class Job(Schema):
     a: Column[IntegerType]
     c: Column[IntegerType]
+
+
+class Age(Schema):
+    age_1: Column[IntegerType]
+    age_2: Column[IntegerType]
 
 
 def test_register_schema_to_dataset(spark: SparkSession):
@@ -29,3 +48,44 @@ def test_register_schema_to_dataset(spark: SparkSession):
     assert person.get_schema_name() == "Person"
 
     df_a.join(df_b, person.a == job.a)
+
+
+def test_register_schema_to_dataset_with_alias(spark: SparkSession):
+    df = create_partially_filled_dataset(
+        spark,
+        Person,
+        {
+            Person.a: [1, 2, 3],
+            Person.b: [1, 2, 3],
+            Person.pets: create_partially_filled_dataset(
+                spark,
+                Pets,
+                {
+                    Pets.name: ["Bobby", "Bobby", "Bobby"],
+                    Pets.age: [10, 20, 30],
+                },
+            ).collect(),
+        },
+    )
+
+    with pytest.raises(AnalysisException):
+        df_a = df.alias("a")
+        df_b = df.alias("b")
+        schema_a = register_schema_to_dataset(df_a, Person)
+        schema_b = register_schema_to_dataset(df_b, Person)
+        df_a.join(df_b, schema_a.a == schema_b.b)
+
+    df_a, schema_a = register_schema_to_dataset_with_alias(df, Person, "a")
+    df_b, schema_b = register_schema_to_dataset_with_alias(df, Person, "b")
+    joined = df_a.join(df_b, schema_a.a == schema_b.b)
+
+    res = joined.select(
+        schema_a.pets.dtype.schema.age.alias(Age.age_1.str),
+        schema_b.pets.dtype.schema.age.alias(Age.age_2.str),
+    )
+
+    expected = create_partially_filled_dataset(
+        spark, Age, {Age.age_1: [10, 20, 30], Age.age_2: [10, 20, 30]}
+    )
+
+    assert_df_equality(res, expected)

--- a/typedspark/__init__.py
+++ b/typedspark/__init__.py
@@ -21,7 +21,10 @@ from typedspark._utils.create_dataset import (
 )
 from typedspark._utils.databases import Catalogs, Database, Databases
 from typedspark._utils.load_table import create_schema, load_table
-from typedspark._utils.register_schema_to_dataset import register_schema_to_dataset
+from typedspark._utils.register_schema_to_dataset import (
+    register_schema_to_dataset,
+    register_schema_to_dataset_with_alias,
+)
 
 __all__ = [
     "ArrayType",
@@ -44,6 +47,7 @@ __all__ = [
     "create_schema",
     "load_table",
     "register_schema_to_dataset",
+    "register_schema_to_dataset_with_alias",
     "structtype_column",
     "transform_to_schema",
 ]

--- a/typedspark/_core/column.py
+++ b/typedspark/_core/column.py
@@ -37,6 +37,7 @@ class Column(SparkColumn, Generic[T]):
         curid: Optional[int] = None,
         dtype: Optional[T] = None,
         parent: Union[DataFrame, "Column", None] = None,
+        alias: Optional[str] = None,
     ):
         """``__new__()`` instantiates the object (prior to ``__init__()``).
 
@@ -55,10 +56,12 @@ class Column(SparkColumn, Generic[T]):
         column: SparkColumn
         if SparkSession.getActiveSession() is None:
             column = EmptyColumn()  # pragma: no cover
-        elif parent is None:
-            column = col(name)
-        else:
+        elif alias is not None:
+            column = col(f"{alias}.{name}")
+        elif parent is not None:
             column = parent[name]
+        else:
+            column = col(name)
 
         column.__class__ = Column
         return column
@@ -70,6 +73,7 @@ class Column(SparkColumn, Generic[T]):
         curid: Optional[int] = None,
         dtype: Optional[T] = None,
         parent: Union[DataFrame, "Column", None] = None,
+        alias: Optional[str] = None,
     ):
         # pylint: disable=unused-argument
         self.str = name

--- a/typedspark/_core/dataset.py
+++ b/typedspark/_core/dataset.py
@@ -95,6 +95,9 @@ class DataSet(DataFrame, Generic[T]):
     don't affect the ``Schema``, we can add type annotations here. We're omitting docstrings,
     such that the docstring from the parent will appear."""
 
+    def alias(self, alias: str) -> "DataSet[T]":
+        return DataSet[self._schema_annotations](super().alias(alias))  # type: ignore
+
     def distinct(self) -> "DataSet[T]":  # pylint: disable=C0116
         return DataSet[self._schema_annotations](super().distinct())  # type: ignore
 

--- a/typedspark/_schema/schema.py
+++ b/typedspark/_schema/schema.py
@@ -31,6 +31,7 @@ class MetaSchema(type):
     """
 
     _parent: Optional[Union[DataFrame, Column]] = None
+    _alias: Optional[str] = None
     _current_id: Optional[int] = None
     _original_name: Optional[str] = None
 
@@ -78,6 +79,7 @@ class MetaSchema(type):
                 dtype=cls._get_dtype(name),  # type: ignore
                 parent=cls._parent,
                 curid=cls._current_id,
+                alias=cls._alias,
             )
 
         raise TypeError(f"Schema {cls.get_schema_name()} does not have attribute {name}.")
@@ -100,8 +102,8 @@ class MetaSchema(type):
         return list(get_type_hints(cls).keys())
 
     def all_column_names_except_for(cls, except_for: List[str]) -> List[str]:
-        """Returns all column names for a given schema except for the columns
-        specified in the ``except_for`` parameter."""
+        """Returns all column names for a given schema except for the columns specified
+        in the ``except_for`` parameter."""
         return list(name for name in get_type_hints(cls).keys() if name not in except_for)
 
     def get_snake_case(cls) -> str:
@@ -161,8 +163,7 @@ class MetaSchema(type):
         )
 
     def get_dlt_kwargs(cls, name: Optional[str] = None) -> DltKwargs:
-        """Creates a representation of the ``Schema`` to be used by Delta Live
-        Tables.
+        """Creates a representation of the ``Schema`` to be used by Delta Live Tables.
 
         .. code-block:: python
 

--- a/typedspark/_utils/register_schema_to_dataset.py
+++ b/typedspark/_utils/register_schema_to_dataset.py
@@ -66,9 +66,21 @@ def register_schema_to_dataset(dataframe: DataSet[T], schema: Type[T]) -> Type[T
 def register_schema_to_dataset_with_alias(
     dataframe: DataSet[T], schema: Type[T], alias: str
 ) -> Tuple[DataSet[T], Type[T]]:
-    """Helps combat column ambiguity.
+    """When dealing with self-joins, running `register_dataset_to_schema()` is not
+    enough.
 
-    For example:
+    Instead, we'll need `register_dataset_to_schema_with_alias()`, e.g.:
+
+    .. code-block:: python
+
+        class Person(Schema):
+            id: Column[IntegerType]
+            name: Column[StringType]
+
+        df_a, person_a = register_schema_to_dataset_with_alias(df, Person, alias="a")
+        df_b, person_b = register_schema_to_dataset_with_alias(df, Person, alias="b")
+
+        df_a.join(df_b, person_a.id == person_b.id)
     """
 
     class LinkedSchema(schema):  # type: ignore  # pylint: disable=missing-class-docstring

--- a/typedspark/_utils/register_schema_to_dataset.py
+++ b/typedspark/_utils/register_schema_to_dataset.py
@@ -1,6 +1,6 @@
 """Module containing functions that are related to registering schema's to DataSets."""
 import itertools
-from typing import Type, TypeVar
+from typing import Tuple, Type, TypeVar
 
 from typedspark._core.dataset import DataSet
 from typedspark._schema.schema import Schema
@@ -61,3 +61,22 @@ def register_schema_to_dataset(dataframe: DataSet[T], schema: Type[T]) -> Type[T
         _original_name = schema.get_schema_name()
 
     return LinkedSchema  # type: ignore
+
+
+def register_schema_to_dataset_with_alias(
+    dataframe: DataSet[T], schema: Type[T], alias: str
+) -> Tuple[DataSet[T], Type[T]]:
+    """Helps combat column ambiguity.
+
+    For example:
+    """
+
+    class LinkedSchema(schema):  # type: ignore  # pylint: disable=missing-class-docstring
+        _current_id = _counter()
+        _original_name = schema.get_schema_name()
+        _alias = alias
+
+    return (
+        dataframe.alias(alias),
+        LinkedSchema,  # type: ignore
+    )


### PR DESCRIPTION
Allows for self-joins, such as:
```python
from typedspark import register_schema_to_dataset_with_alias


df = create_partially_filled_dataset(
    spark,
    Person,
    {
        Person.id: [1, 2, 3],
        Person.name: ["Alice", "Bob", "Charlie"],
        Person.age: [20, 30, 40],
    },
)

df_a, person_a = register_schema_to_dataset_with_alias(df, Person, alias="a")
df_b, person_b = register_schema_to_dataset_with_alias(df, Person, alias="b")

df_a.join(df_b, person_a.id == person_b.id)
```