### PR TITLE
Add test to cover the counter in register_schema_to_dataset method

### DIFF
--- a/tests/_utils/test_register_schema_to_dataset.py
+++ b/tests/_utils/test_register_schema_to_dataset.py
@@ -27,5 +27,6 @@ def test_register_schema_to_dataset(spark: SparkSession):
     job = register_schema_to_dataset(df_b, Job)
 
     assert person.get_schema_name() == "Person"
+    assert hash(person.a) != hash(Person.a)
 
     df_a.join(df_b, person.a == job.a)


### PR DESCRIPTION
I couldn't remember anymore why we had this counter and I noticed no tests broke when I removed it. After a while I remembered and decided to add a test to cover this for future reference.