### PR TITLE
fix DataSetImplements such that we can use functools.reduce again

### DIFF
--- a/tests/_core/test_dataset.py
+++ b/tests/_core/test_dataset.py
@@ -1,3 +1,5 @@
+import functools
+
 import pandas as pd
 import pytest
 from pyspark.sql import SparkSession
@@ -94,3 +96,10 @@ def test_schema_property_of_dataset(spark: SparkSession):
 def test_initialize_dataset_implements(spark: SparkSession):
     with pytest.raises(NotImplementedError):
         DataSetImplements()
+
+
+def test_reduce(spark: SparkSession):
+    functools.reduce(
+        DataSet.unionByName,
+        [create_empty_dataset(spark, A), create_empty_dataset(spark, A)],
+    )


### PR DESCRIPTION
In the current master, the following code results in linting errors:
```python
functools.reduce(
    DataSet.unionByName,
    [create_empty_dataset(spark, A), create_empty_dataset(spark, A)],
)
```

This is at odds with earlier versions of typedspark. This PR fixes the behaviour so that it's consistent with earlier versions.