### PR TITLE
Add a monkeypatch to allow for df.to_typedspark method

### DIFF
--- a/docs/source/create_schema_in_notebook.ipynb
+++ b/docs/source/create_schema_in_notebook.ipynb
@@ -217,7 +217,56 @@
    "cell_type": "markdown",
    "id": "18ea295c",
    "metadata": {},
-   "source": []
+   "source": [
+    "## Monkeypatch\n",
+    "\n",
+    "We also support doing the above directly in a function-chain using a monkeypatch. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50d02f7e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pivot, Pivot = (\n",
+    "    vaccinations.groupby(Vaccinations.pet_id)\n",
+    "    .pivot(Vaccinations.vaccine_name.str)\n",
+    "    .agg(first(Vaccinations.next_due_date))\n",
+    "    .to_typedspark()\n",
+    ")\n",
+    "pivot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2cbe246",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Pivot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6c8b2cd",
+   "metadata": {},
+   "source": [
+    "Using the monkeypatched form comes with pros and cons. The pros:\n",
+    "\n",
+    "* No need for intermediate variables\n",
+    "* No need to import `create_schema()`\n",
+    "* Both contribute to a more straightforward workflow\n",
+    "\n",
+    "And cons:\n",
+    "\n",
+    "* The `to_typedspark()` function is glued against against the `DataFrame` class once we import anything from `typedspark`.\n",
+    "* This often means that `to_typedspark()` will not show up during autocomplete, so you'll have to type it yourself.\n",
+    "* For the same reason, typecheckers may raise a linting error.\n",
+    "* And finally, it only works if you've imported something from typedspark already. Shouldn't be a major problem (you'll likely have imported `Catalogs`, for example), but it's something to be aware of.\n"
+   ]
   }
  ],
  "metadata": {

--- a/docs/source/create_schema_in_notebook.ipynb
+++ b/docs/source/create_schema_in_notebook.ipynb
@@ -225,10 +225,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "50d02f7e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------+----------+----------+----------+\n",
+      "|pet_id| influenza|      lyme|    rabies|\n",
+      "+------+----------+----------+----------+\n",
+      "|     1|      NULL|2023-10-17|2023-11-03|\n",
+      "|     2|2023-10-03|      NULL|2023-10-08|\n",
+      "|     3|2023-10-05|2023-10-04|2023-10-14|\n",
+      "+------+----------+----------+----------+\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "pivot, Pivot = (\n",
     "    vaccinations.groupby(Vaccinations.pet_id)\n",
@@ -241,10 +256,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "a2cbe246",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "from pyspark.sql.types import DateType, LongType\n",
+       "\n",
+       "from typedspark import Column, Schema\n",
+       "\n",
+       "\n",
+       "class DynamicallyLoadedSchema(Schema):\n",
+       "    pet_id: Column[LongType]\n",
+       "    influenza: Column[DateType]\n",
+       "    lyme: Column[DateType]\n",
+       "    rabies: Column[DateType]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Pivot"
    ]

--- a/docs/source/type_checking.ipynb
+++ b/docs/source/type_checking.ipynb
@@ -157,7 +157,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Data contains the following columns not present in schema Person: {'gender'}\n"
+      "Data contains the following columns not present in schema Person: {'gender'}.\n",
+      "\n",
+      "If you believe these columns should be part of the schema, consider adding the following lines to it.\n",
+      "\n",
+      "class Person(Schema):\n",
+      "    gender: Column[StringType]\n",
+      "\n"
      ]
     }
    ],

--- a/typedspark/_utils/load_table.py
+++ b/typedspark/_utils/load_table.py
@@ -65,8 +65,7 @@ def _replace_illegal_characters(column_name: str) -> str:
 
 
 def _create_schema(structtype: SparkStructType, schema_name: Optional[str] = None) -> Type[Schema]:
-    """Dynamically builds a ``Schema`` based on a ``DataFrame``'s
-    ``StructType``"""
+    """Dynamically builds a ``Schema`` based on a ``DataFrame``'s ``StructType``"""
     type_annotations = {}
     attributes: Dict[str, None] = {}
     for column in structtype:
@@ -85,9 +84,8 @@ def _create_schema(structtype: SparkStructType, schema_name: Optional[str] = Non
 
 
 def _extract_data_type(dtype: DataType, name: str) -> Type[DataType]:
-    """Given an instance of a ``DataType``, it extracts the corresponding
-    ``DataType`` class, potentially including annotations (e.g.
-    ``ArrayType[StringType]``)."""
+    """Given an instance of a ``DataType``, it extracts the corresponding ``DataType``
+    class, potentially including annotations (e.g. ``ArrayType[StringType]``)."""
     if isinstance(dtype, SparkArrayType):
         element_type = _extract_data_type(dtype.elementType, name)
         return ArrayType[element_type]  # type: ignore
@@ -117,7 +115,8 @@ def _extract_data_type(dtype: DataType, name: str) -> Type[DataType]:
 def create_schema(
     dataframe: DataFrame, schema_name: Optional[str] = None
 ) -> Tuple[DataSet[Schema], Type[Schema]]:
-    """This function inferres a ``Schema`` in a notebook based on a the provided ``DataFrame``.
+    """This function inferres a ``Schema`` in a notebook based on a the provided
+    ``DataFrame``.
 
     This allows for autocompletion on column names, amongst other
     things.
@@ -136,8 +135,8 @@ def create_schema(
 def load_table(
     spark: SparkSession, table_name: str, schema_name: Optional[str] = None
 ) -> Tuple[DataSet[Schema], Type[Schema]]:
-    """This function loads a ``DataSet``, along with its inferred ``Schema``,
-    in a notebook.
+    """This function loads a ``DataSet``, along with its inferred ``Schema``, in a
+    notebook.
 
     This allows for autocompletion on column names, amongst other
     things.
@@ -148,3 +147,6 @@ def load_table(
     """
     dataframe = spark.table(table_name)
     return create_schema(dataframe, schema_name)
+
+
+DataFrame.to_typedspark = create_schema  # type: ignore


### PR DESCRIPTION
Allows for the following notation:
```python
pivot, Pivot = (
    vaccinations.groupby(Vaccinations.pet_id)
    .pivot(Vaccinations.vaccine_name.str)
    .agg(first(Vaccinations.next_due_date))
    .to_typedspark()
)
```

Instead of (or in addition to):
```python
pivot = (
    vaccinations.groupby(Vaccinations.pet_id)
    .pivot(Vaccinations.vaccine_name.str)
    .agg(first(Vaccinations.next_due_date))
)

pivot, Pivot = create_schema(pivot)
pivot.show()
```