### PR TITLE
Improve SEO for documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,6 @@
 .. include:: README.rst
 
 .. toctree::
-   :hidden:
    
    README
    ide


### PR DESCRIPTION
Add an index to the first page of the readthedocs, such that google will be able to index our documentation.