### PR TITLE
add include docstring to schema generating functions

### DIFF
--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -141,7 +141,12 @@ def _replace_literal(
     )
 
 
-def _add_subschemas(schema: Type[Schema], add_subschemas: bool, include_docstring: bool, include_documentation: bool) -> str:
+def _add_subschemas(
+    schema: Type[Schema], 
+    add_subschemas: bool, 
+    include_docstring: bool, 
+    include_documentation: bool
+) -> str:
     """Identifies whether any ``Column`` are of the ``StructType`` type and generates
     their schema recursively."""
     lines = ""
@@ -155,7 +160,11 @@ def _add_subschemas(schema: Type[Schema], add_subschemas: bool, include_docstrin
             lines += "\n\n"
             subschema: Type[Schema] = get_args(dtype)[0]
             lines += _build_schema_definition_string(
-                subschema, include_docstring, include_documentation, add_subschemas, subschema.get_schema_name()
+                subschema, 
+                include_docstring, 
+                include_documentation, 
+                add_subschemas, 
+                subschema.get_schema_name(),
             )
 
     return lines

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def get_schema_definition_as_string(
     schema: Type[Schema],
+    include_docstring: bool,
     include_documentation: bool,
     generate_imports: bool,
     add_subschemas: bool,
@@ -28,7 +29,7 @@ def get_schema_definition_as_string(
     """
     imports = get_schema_imports(schema, include_documentation) if generate_imports else ""
     schema_string = _build_schema_definition_string(
-        schema, include_documentation, add_subschemas, class_name
+        schema, include_docstring, include_documentation, add_subschemas, class_name
     )
 
     return imports + schema_string
@@ -36,6 +37,7 @@ def get_schema_definition_as_string(
 
 def _build_schema_definition_string(
     schema: Type[Schema],
+    include_docstring: bool,
     include_documentation: bool,
     add_subschemas: bool,
     class_name: str = "MyNewSchema",
@@ -43,13 +45,13 @@ def _build_schema_definition_string(
     """Return the code for a given ``Schema`` as a string."""
     lines = f"class {class_name}(Schema):\n"
 
-    if include_documentation:
+    if include_docstring:
         lines += _create_docstring(schema)
 
     lines += _add_lines_with_typehint(include_documentation, schema)
 
     if add_subschemas:
-        lines += _add_subschemas(schema, add_subschemas, include_documentation)
+        lines += _add_subschemas(schema, add_subschemas, include_docstring, include_documentation)
 
     return lines
 
@@ -139,7 +141,7 @@ def _replace_literal(
     )
 
 
-def _add_subschemas(schema: Type[Schema], add_subschemas: bool, include_documentation: bool) -> str:
+def _add_subschemas(schema: Type[Schema], add_subschemas: bool, include_docstring: bool, include_documentation: bool) -> str:
     """Identifies whether any ``Column`` are of the ``StructType`` type and generates
     their schema recursively."""
     lines = ""
@@ -153,7 +155,7 @@ def _add_subschemas(schema: Type[Schema], add_subschemas: bool, include_document
             lines += "\n\n"
             subschema: Type[Schema] = get_args(dtype)[0]
             lines += _build_schema_definition_string(
-                subschema, include_documentation, add_subschemas, subschema.get_schema_name()
+                subschema, include_docstring, include_documentation, add_subschemas, subschema.get_schema_name()
             )
 
     return lines

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Type, get_args, get_origin, get_type_hints
 
-from typedspark._core.datatypes import DayTimeIntervalType, StructType, TypedSparkDataType
+from typedspark._core.datatypes import (
+    DayTimeIntervalType,
+    StructType,
+    TypedSparkDataType,
+)
 from typedspark._core.literaltype import IntervalType, LiteralType
 from typedspark._schema.get_schema_imports import get_schema_imports
 
@@ -27,7 +31,9 @@ def get_schema_definition_as_string(
     schema in your code base. When ``generate_imports`` is True, the
     required imports for the schema are included in the string.
     """
-    imports = get_schema_imports(schema, include_documentation) if generate_imports else ""
+    imports = (
+        get_schema_imports(schema, include_documentation) if generate_imports else ""
+    )
     schema_string = _build_schema_definition_string(
         schema, include_docstring, include_documentation, add_subschemas, class_name
     )
@@ -51,7 +57,9 @@ def _build_schema_definition_string(
     lines += _add_lines_with_typehint(include_documentation, schema)
 
     if add_subschemas:
-        lines += _add_subschemas(schema, add_subschemas, include_docstring, include_documentation)
+        lines += _add_subschemas(
+            schema, add_subschemas, include_docstring, include_documentation
+        )
 
     return lines
 
@@ -91,7 +99,9 @@ def _create_typehint_and_comment(col_type) -> list[str]:
     )
     typehint, comment = _extract_comment(typehint)
     typehint = _replace_literals(
-        typehint, replace_literals_in=DayTimeIntervalType, replace_literals_by=IntervalType
+        typehint,
+        replace_literals_in=DayTimeIntervalType,
+        replace_literals_by=IntervalType,
     )
     return [typehint, comment]
 
@@ -118,7 +128,9 @@ def _replace_literals(
     """
     mapping = replace_literals_by.get_inverse_dict()
     for original, replacement in mapping.items():
-        typehint = _replace_literal(typehint, replace_literals_in, original, replacement)
+        typehint = _replace_literal(
+            typehint, replace_literals_in, original, replacement
+        )
 
     return typehint
 
@@ -145,7 +157,7 @@ def _add_subschemas(
     schema: Type[Schema],
     add_subschemas: bool,
     include_docstring: bool,
-    include_documentation: bool
+    include_documentation: bool,
 ) -> str:
     """Identifies whether any ``Column`` are of the ``StructType`` type and generates
     their schema recursively."""

--- a/typedspark/_schema/get_schema_definition.py
+++ b/typedspark/_schema/get_schema_definition.py
@@ -142,9 +142,9 @@ def _replace_literal(
 
 
 def _add_subschemas(
-    schema: Type[Schema], 
-    add_subschemas: bool, 
-    include_docstring: bool, 
+    schema: Type[Schema],
+    add_subschemas: bool,
+    include_docstring: bool,
     include_documentation: bool
 ) -> str:
     """Identifies whether any ``Column`` are of the ``StructType`` type and generates
@@ -160,10 +160,10 @@ def _add_subschemas(
             lines += "\n\n"
             subschema: Type[Schema] = get_args(dtype)[0]
             lines += _build_schema_definition_string(
-                subschema, 
-                include_docstring, 
-                include_documentation, 
-                add_subschemas, 
+                subschema,
+                include_docstring,
+                include_documentation,
+                add_subschemas,
                 subschema.get_schema_name(),
             )
 

--- a/typedspark/_schema/schema.py
+++ b/typedspark/_schema/schema.py
@@ -133,6 +133,7 @@ class MetaSchema(_ProtocolMeta):  # type: ignore
     def get_schema_definition_as_string(
         cls,
         schema_name: Optional[str] = None,
+        include_docstring: bool = False,
         include_documentation: bool = False,
         generate_imports: bool = True,
         add_subschemas: bool = True,
@@ -142,6 +143,7 @@ class MetaSchema(_ProtocolMeta):  # type: ignore
             schema_name = cls.get_schema_name()
         return get_schema_definition_as_string(
             cls,  # type: ignore
+            include_docstring,
             include_documentation,
             generate_imports,
             add_subschemas,


### PR DESCRIPTION
Adds additional flag to schema generating functions that specifies adding docstrings.

Before this PR: schema docstrings would be included in the include_documentation flag.
After this PR: one can choose to have docstrings but not column comments in column meta.