### PR TITLE
Provide auto-complete in notebooks for table names starting with an underscore

### DIFF
--- a/docs/source/loading_datasets_in_notebooks.ipynb
+++ b/docs/source/loading_datasets_in_notebooks.ipynb
@@ -43,16 +43,15 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "(\n",
-    "    spark.createDataFrame(\n",
-    "        pd.DataFrame(\n",
-    "            dict(\n",
-    "                name=[\"Jack\", \"John\", \"Jane\"],\n",
-    "                age=[20, 30, 40],\n",
-    "            )\n",
+    "df = spark.createDataFrame(\n",
+    "    pd.DataFrame(\n",
+    "        dict(\n",
+    "            name=[\"Jack\", \"John\", \"Jane\"],\n",
+    "            age=[20, 30, 40],\n",
     "        )\n",
-    "    ).createOrReplaceTempView(\"person_table\")\n",
-    ")"
+    "    )\n",
+    ")\n",
+    "df.createOrReplaceTempView(\"person_table\")"
    ]
   },
   {
@@ -229,9 +228,7 @@
    "id": "63e3cc44",
    "metadata": {},
    "source": [
-    "Note that `Catalog()` automatically runs `register_schema_to_dataset()` on the resulting `DataSet` and `Schema`, hence resolving potential column disambiguities.\n",
-    "\n",
-    "If any names (of tables, databases, or catalogs) start with an underscore, they will get the prefix `u` in the autocomplete (for example, `db.spark_catalog.default._persons` would be changed to `db.spark_catalog.default.u_persons`). This helps avoid the situation where a notebook doesn't provide autocomplete due to the corresponding attribute being considered as private. If the `u_persons` already exists, the prefix will get extra underscores (e.g. `u__persons`) to prevent naming conflicts."
+    "Note that `Catalog()` automatically runs `register_schema_to_dataset()` on the resulting `DataSet` and `Schema`, hence resolving potential column disambiguities."
    ]
   },
   {
@@ -302,12 +299,60 @@
   },
   {
    "cell_type": "markdown",
+   "id": "071cd277",
+   "metadata": {},
+   "source": [
+    "# Names starting with an underscore\n",
+    "\n",
+    "For `Catalogs()`, `Databases()` and `Database()`, names starting with an underscore are problematic for auto-complete. For example, suppose we'd make this table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acfd55af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.write.saveAsTable(\"default._person\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fcf12ef",
+   "metadata": {},
+   "source": [
+    "Then we won't get auto-complete using `db._person`, since our notebook will assume we don't want auto-complete on private variables. To circumvent this, we rename the attribute as such:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7f41731",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "persons, Person = db.u_person()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e1b3aaa",
+   "metadata": {},
+   "source": [
+    "The underlying table is not renamed, solely the class attribute used for autocomplete.\n",
+    "\n",
+    "When renaming the attribute leads to a naming conflict (e.g. because `u_person` already exists), we resolve the conflict by adding more underscores (e.g. `_person` would then become `u__person`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e0187268",
    "metadata": {},
    "source": [
     "## Loading a single DataSet\n",
     "\n",
-    "Finally, if you really only want to load one DataSet, you can use `load_table()`."
+    "If you really only want to load one DataSet, you can use `load_table()`."
    ]
   },
   {

--- a/docs/source/loading_datasets_in_notebooks.ipynb
+++ b/docs/source/loading_datasets_in_notebooks.ipynb
@@ -229,7 +229,9 @@
    "id": "63e3cc44",
    "metadata": {},
    "source": [
-    "Of note, `Catalog()` automatically runs `register_schema_to_dataset()` on the resulting `DataSet` and `Schema`, hence resolving potential column disambiguities."
+    "Note that `Catalog()` automatically runs `register_schema_to_dataset()` on the resulting `DataSet` and `Schema`, hence resolving potential column disambiguities.\n",
+    "\n",
+    "If any names (of tables, databases, or catalogs) start with an underscore, they will get the prefix `u` in the autocomplete (for example, `db.spark_catalog.default._persons` would be changed to `db.spark_catalog.default.u_persons`). This helps avoid the situation where a notebook doesn't provide autocomplete due to the corresponding attribute being considered as private. If the `u_persons` already exists, the prefix will get extra underscores (e.g. `u__persons`) to prevent naming conflicts."
    ]
   },
   {

--- a/docs/source/loading_datasets_in_notebooks.ipynb
+++ b/docs/source/loading_datasets_in_notebooks.ipynb
@@ -328,6 +328,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b0491ad1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db = Database()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "f7f41731",
    "metadata": {},
    "outputs": [],

--- a/docs/source/loading_datasets_in_notebooks.ipynb
+++ b/docs/source/loading_datasets_in_notebooks.ipynb
@@ -228,7 +228,7 @@
    "id": "63e3cc44",
    "metadata": {},
    "source": [
-    "Note that `Catalog()` automatically runs `register_schema_to_dataset()` on the resulting `DataSet` and `Schema`, hence resolving potential column disambiguities."
+    "Of note, `Catalog()` automatically runs `register_schema_to_dataset()` on the resulting `DataSet` and `Schema`, hence resolving potential column disambiguities."
    ]
   },
   {


### PR DESCRIPTION
Suppose we'd make this table.
```python
df.write.saveAsTable("default._person")
```
And then we try to load it using `Databases()` (or any of the related classes).
```python
db = Databases()
```
Then we don't get auto-complete, because our notebook assumes that we don't want to access private variables. To circumvent this, we rename the attribute as such:
```python
person, _person = db.default.u_person()
```

The underlying table is not renamed, solely the class attribute used for autocomplete.

When renaming the attribute leads to a naming conflict (e.g. because `u_person` already exists), we resolve the conflict by adding more underscores (e.g. `_person` would then become `u__person`).