### PR TITLE
Swap DataFrame.withColumn() for more performant DataFrame.withColumns()

### DIFF
--- a/tests/_transforms/test_transform_to_schema.py
+++ b/tests/_transforms/test_transform_to_schema.py
@@ -174,3 +174,23 @@ def test_transform_to_schema_sequential(spark: SparkSession):
     )
 
     assert_df_equality(observed, expected)
+
+
+def test_transform_to_schema_with_with_columns(spark: SparkSession):
+    df = create_partially_filled_dataset(spark, Person, {Person.a: [1, 2, 3], Person.b: [1, 2, 3]})
+
+    observed = transform_to_schema(
+        df,
+        Person,
+        {
+            Person.a: Person.a + 3,
+            Person.b: Person.a + 5,
+        },
+        use_with_columns=True,
+    )
+
+    expected = create_partially_filled_dataset(
+        spark, Person, {Person.a: [4, 5, 6], Person.b: [6, 7, 8]}
+    )
+
+    assert_df_equality(observed, expected)

--- a/tests/_transforms/test_transform_to_schema.py
+++ b/tests/_transforms/test_transform_to_schema.py
@@ -176,7 +176,7 @@ def test_transform_to_schema_sequential(spark: SparkSession):
     assert_df_equality(observed, expected)
 
 
-def test_transform_to_schema_with_with_columns(spark: SparkSession):
+def test_transform_to_schema_parallel(spark: SparkSession):
     df = create_partially_filled_dataset(spark, Person, {Person.a: [1, 2, 3], Person.b: [1, 2, 3]})
 
     observed = transform_to_schema(
@@ -186,7 +186,7 @@ def test_transform_to_schema_with_with_columns(spark: SparkSession):
             Person.a: Person.a + 3,
             Person.b: Person.a + 5,
         },
-        use_with_columns=True,
+        run_sequentially=False,
     )
 
     expected = create_partially_filled_dataset(

--- a/typedspark/_transforms/transform_to_schema.py
+++ b/typedspark/_transforms/transform_to_schema.py
@@ -16,16 +16,16 @@ T = TypeVar("T", bound=Schema)
 
 
 def _do_transformations(
-    dataframe: DataFrame, transformations: Dict[str, SparkColumn], run_sequentially: bool = False
+    dataframe: DataFrame, transformations: Dict[str, SparkColumn], run_sequentially: bool = True
 ) -> DataFrame:
     """Performs the transformations on the provided DataFrame."""
     if run_sequentially:
-        return DataFrame.withColumns(dataframe, transformations)
-    return reduce(
-        lambda acc, key: DataFrame.withColumn(acc, key, transformations[key]),
-        transformations.keys(),
-        dataframe,
-    )
+        return reduce(
+            lambda acc, key: DataFrame.withColumn(acc, key, transformations[key]),
+            transformations.keys(),
+            dataframe,
+        )
+    return DataFrame.withColumns(dataframe, transformations)
 
 
 def _rename_temporary_keys_to_original_keys(

--- a/typedspark/_transforms/transform_to_schema.py
+++ b/typedspark/_transforms/transform_to_schema.py
@@ -17,11 +17,7 @@ T = TypeVar("T", bound=Schema)
 
 def _do_transformations(dataframe: DataFrame, transformations: Dict[str, SparkColumn]) -> DataFrame:
     """Performs the transformations on the provided DataFrame."""
-    return reduce(
-        lambda acc, key: DataFrame.withColumn(acc, key, transformations[key]),
-        transformations.keys(),
-        dataframe,
-    )
+    return DataFrame.withColumns(dataframe, transformations)
 
 
 def _rename_temporary_keys_to_original_keys(

--- a/typedspark/_transforms/transform_to_schema.py
+++ b/typedspark/_transforms/transform_to_schema.py
@@ -16,10 +16,10 @@ T = TypeVar("T", bound=Schema)
 
 
 def _do_transformations(
-    dataframe: DataFrame, transformations: Dict[str, SparkColumn], use_with_columns: bool = False
+    dataframe: DataFrame, transformations: Dict[str, SparkColumn], run_sequentially: bool = False
 ) -> DataFrame:
     """Performs the transformations on the provided DataFrame."""
-    if use_with_columns:
+    if run_sequentially:
         return DataFrame.withColumns(dataframe, transformations)
     return reduce(
         lambda acc, key: DataFrame.withColumn(acc, key, transformations[key]),
@@ -44,7 +44,7 @@ def transform_to_schema(
     schema: Type[T],
     transformations: Optional[Dict[Column, SparkColumn]] = None,
     fill_unspecified_columns_with_nulls: bool = False,
-    use_with_columns: bool = False,
+    run_sequentially: bool = True,
 ) -> DataSet[T]:
     """On the provided DataFrame ``df``, it performs the ``transformations`` (if
     provided), and subsequently subsets the resulting DataFrame to the columns specified
@@ -72,7 +72,7 @@ def transform_to_schema(
     transform = RenameDuplicateColumns(transform, schema, dataframe.columns)
 
     return DataSet[schema](  # type: ignore
-        dataframe.transform(_do_transformations, transform.transformations, use_with_columns)
+        dataframe.transform(_do_transformations, transform.transformations, run_sequentially)
         .drop(*transform.temporary_key_mapping.keys())
         .transform(_rename_temporary_keys_to_original_keys, transform.temporary_key_mapping)
         .select(*schema.all_column_names())


### PR DESCRIPTION
`df.withColumns()` is generally more performant than multiple `.withColumn()` calls. See this [article](https://www.guptaakashdeep.com/how-withcolumn-can-degrade-the-performance-of-a-spark-job/) for more information.

Note that I couldn't get the spark tests running due to my local spark setup being a little weird. Could a maintainer provide more detailed installation instructions here and I'll test them out and add to the contributing section of the docs as part of this PR?