### PR TITLE
fill_unspecified_inner_fields_with_nulls

### DIFF
--- a/docs/source/transforming_datasets.ipynb
+++ b/docs/source/transforming_datasets.ipynb
@@ -194,7 +194,24 @@
    "cell_type": "markdown",
    "id": "6546f023",
    "metadata": {},
-   "source": []
+   "source": [
+    "## Filling missing columns and nested fields with null\n",
+    "\n",
+    "`transform_to_schema()` accepts two flags:\n",
+    "- `fill_unspecified_columns_with_nulls`. When True, it adds null for any top-level column present in the target schema but absent from the source dataframe.\n",
+    "\n",
+    "- `fill_unspecified_inner_fields_with_nulls`. When True handles the complementary case: the top-level column exists in both, but the nested type inside it (structs, array of structs, or map of structs) is missing fields required by the target schema. Those missing fields are filled with null in-place, recursively.\n",
+    "\n",
+    "Use both together when the source data is structurally incomplete at any level relative to the target schema.\n"
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "",
+   "id": "e0caa88ff0e2054e"
   }
  ],
  "metadata": {

--- a/tests/_transforms/test_transform_to_schema.py
+++ b/tests/_transforms/test_transform_to_schema.py
@@ -382,7 +382,7 @@ def test_fill_unspecified_inner_fields_in_map(spark: SparkSession):
 
 
 def test_fill_unspecified_inner_fields_skips_explicitly_transformed_columns(spark: SparkSession):
-    """Line 132: columns already in transformations are skipped by auto-fill."""
+    """Columns already in transformations should be skipped by auto-fill."""
     from pyspark.sql import functions as F
 
     class TopStructFull(Schema):
@@ -412,9 +412,8 @@ def test_fill_unspecified_inner_fields_skips_explicitly_transformed_columns(spar
 
 
 def test_fill_unspecified_inner_fields_skips_columns_absent_from_data(spark: SparkSession):
-    """Line 134: fill_unspecified_inner_fields_with_nulls skips top-level columns
-    absent from the data — they are not its responsibility. Without
-    fill_unspecified_columns_with_nulls the missing column causes an error."""
+    """fill_unspecified_inner_fields_with_nulls should skips top-level columns
+    absent from the data. Without fill_unspecified_columns_with_nulls the missing column should cause an error."""
 
     class IdOnly(Schema):
         id: Column[IntegerType]
@@ -434,8 +433,7 @@ def test_fill_unspecified_inner_fields_skips_columns_absent_from_data(spark: Spa
 
 
 def test_fill_unspecified_inner_fields_map_key_type_mismatch_raises(spark: SparkSession):
-    """Lines 97 + 107: map key type mismatch enters the transform_keys branch but
-    cannot fix incompatible primitive types, so validation raises TypeError."""
+    """ Map key type mismatch should raises TypeError."""
 
     class TopMapIntKey(Schema):
         id: Column[IntegerType]

--- a/tests/_transforms/test_transform_to_schema.py
+++ b/tests/_transforms/test_transform_to_schema.py
@@ -413,7 +413,8 @@ def test_fill_unspecified_inner_fields_skips_explicitly_transformed_columns(spar
 
 def test_fill_unspecified_inner_fields_skips_columns_absent_from_data(spark: SparkSession):
     """fill_unspecified_inner_fields_with_nulls should skips top-level columns
-    absent from the data. Without fill_unspecified_columns_with_nulls the missing column should cause an error."""
+    absent from the data. Without fill_unspecified_columns_with_nulls the missing column
+    should cause an error."""
 
     class IdOnly(Schema):
         id: Column[IntegerType]

--- a/tests/_transforms/test_transform_to_schema.py
+++ b/tests/_transforms/test_transform_to_schema.py
@@ -434,7 +434,7 @@ def test_fill_unspecified_inner_fields_skips_columns_absent_from_data(spark: Spa
 
 
 def test_fill_unspecified_inner_fields_map_key_type_mismatch_raises(spark: SparkSession):
-    """ Map key type mismatch should raises TypeError."""
+    """Map key type mismatch should raises TypeError."""
 
     class TopMapIntKey(Schema):
         id: Column[IntegerType]

--- a/tests/_transforms/test_transform_to_schema.py
+++ b/tests/_transforms/test_transform_to_schema.py
@@ -412,9 +412,12 @@ def test_fill_unspecified_inner_fields_skips_explicitly_transformed_columns(spar
 
 
 def test_fill_unspecified_inner_fields_skips_columns_absent_from_data(spark: SparkSession):
-    """fill_unspecified_inner_fields_with_nulls should skips top-level columns
-    absent from the data. Without fill_unspecified_columns_with_nulls the missing column
-    should cause an error."""
+    """fill_unspecified_inner_fields_with_nulls should skips top-level columns absent
+    from the data.
+
+    Without fill_unspecified_columns_with_nulls the missing column should cause an
+    error.
+    """
 
     class IdOnly(Schema):
         id: Column[IntegerType]

--- a/tests/_transforms/test_transform_to_schema.py
+++ b/tests/_transforms/test_transform_to_schema.py
@@ -412,8 +412,9 @@ def test_fill_unspecified_inner_fields_skips_explicitly_transformed_columns(spar
 
 
 def test_fill_unspecified_inner_fields_skips_columns_absent_from_data(spark: SparkSession):
-    """Line 134: top-level columns missing from the data are skipped (handled by
-    fill_unspecified_columns_with_nulls instead)."""
+    """Line 134: fill_unspecified_inner_fields_with_nulls skips top-level columns
+    absent from the data — they are not its responsibility. Without
+    fill_unspecified_columns_with_nulls the missing column causes an error."""
 
     class IdOnly(Schema):
         id: Column[IntegerType]
@@ -423,15 +424,13 @@ def test_fill_unspecified_inner_fields_skips_columns_absent_from_data(spark: Spa
         inner: Column[StructType[InnerFull]]
 
     ds = create_partially_filled_dataset(spark, IdOnly, {IdOnly.id: [1, 2]})
-    observed = transform_to_schema(
-        ds,
-        TopStructFull,
-        {},
-        fill_unspecified_columns_with_nulls=True,
-        fill_unspecified_inner_fields_with_nulls=True,
-    )
-    expected = create_partially_filled_dataset(spark, TopStructFull, {TopStructFull.id: [1, 2]})
-    assert_df_equality(observed, expected)
+    with pytest.raises(Exception):
+        transform_to_schema(
+            ds,
+            TopStructFull,
+            {},
+            fill_unspecified_inner_fields_with_nulls=True,
+        )
 
 
 def test_fill_unspecified_inner_fields_map_key_type_mismatch_raises(spark: SparkSession):

--- a/tests/_transforms/test_transform_to_schema.py
+++ b/tests/_transforms/test_transform_to_schema.py
@@ -198,6 +198,7 @@ def test_transform_to_schema_parallel(spark: SparkSession):
 
     assert_df_equality(observed, expected)
 
+
 # Schemas shared across multiple fill_unspecified_inner_fields tests
 
 

--- a/tests/_transforms/test_transform_to_schema.py
+++ b/tests/_transforms/test_transform_to_schema.py
@@ -1,5 +1,6 @@
 import pytest
 from chispa.dataframe_comparer import assert_df_equality  # type: ignore
+from pyspark.errors import AnalysisException
 from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType, StringType
 
@@ -427,7 +428,7 @@ def test_fill_unspecified_inner_fields_skips_columns_absent_from_data(spark: Spa
         inner: Column[StructType[InnerFull]]
 
     ds = create_partially_filled_dataset(spark, IdOnly, {IdOnly.id: [1, 2]})
-    with pytest.raises(TypeError):
+    with pytest.raises(AnalysisException):
         transform_to_schema(
             ds,
             TopStructFull,

--- a/tests/_transforms/test_transform_to_schema.py
+++ b/tests/_transforms/test_transform_to_schema.py
@@ -4,8 +4,11 @@ from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType, StringType
 
 from typedspark import (
+    ArrayType,
     Column,
+    MapType,
     Schema,
+    StructType,
     create_empty_dataset,
     register_schema_to_dataset,
     transform_to_schema,
@@ -193,4 +196,175 @@ def test_transform_to_schema_parallel(spark: SparkSession):
         spark, Person, {Person.a: [4, 5, 6], Person.b: [6, 7, 8]}
     )
 
+    assert_df_equality(observed, expected)
+
+# Schemas shared across multiple fill_unspecified_inner_fields tests
+
+class InnerFull(Schema):
+    x: Column[IntegerType]
+    y: Column[IntegerType]
+
+
+class InnerPartial(Schema):
+    x: Column[IntegerType]
+
+
+class TopStructPartial(Schema):
+    id: Column[IntegerType]
+    inner: Column[StructType[InnerPartial]]
+
+
+def test_fill_unspecified_inner_fields_simple_missing_field(spark: SparkSession):
+    class TopStructFull(Schema):
+        id: Column[IntegerType]
+        inner: Column[StructType[InnerFull]]
+
+    ds = create_partially_filled_dataset(
+        spark,
+        TopStructPartial,
+        {TopStructPartial.id: [1, 2], TopStructPartial.inner: [{"x": 10}, {"x": 20}]},
+    )
+    observed = transform_to_schema(ds, TopStructFull, {}, fill_unspecified_inner_fields_with_nulls=True)
+    expected = create_partially_filled_dataset(
+        spark,
+        TopStructFull,
+        {TopStructFull.id: [1, 2], TopStructFull.inner: [{"x": 10, "y": None}, {"x": 20, "y": None}]},
+    )
+    assert_df_equality(observed, expected)
+
+
+def test_fill_unspecified_inner_fields_deeply_nested(spark: SparkSession):
+    class WrapperFull(Schema):
+        n: Column[IntegerType]
+        leaf: Column[StructType[InnerFull]]
+
+    class WrapperPartial(Schema):
+        n: Column[IntegerType]
+        leaf: Column[StructType[InnerPartial]]
+
+    class TopStructDeepFull(Schema):
+        id: Column[IntegerType]
+        wrapper: Column[StructType[WrapperFull]]
+
+    class TopStructDeepPartial(Schema):
+        id: Column[IntegerType]
+        wrapper: Column[StructType[WrapperPartial]]
+
+    ds = create_partially_filled_dataset(
+        spark,
+        TopStructDeepPartial,
+        {
+            TopStructDeepPartial.id: [1, 2],
+            TopStructDeepPartial.wrapper: [
+                {"n": 1, "leaf": {"x": 10}},
+                {"n": 2, "leaf": {"x": 20}},
+            ],
+        },
+    )
+    observed = transform_to_schema(
+        ds, TopStructDeepFull, {}, fill_unspecified_inner_fields_with_nulls=True
+    )
+    expected = create_partially_filled_dataset(
+        spark,
+        TopStructDeepFull,
+        {
+            TopStructDeepFull.id: [1, 2],
+            TopStructDeepFull.wrapper: [
+                {"n": 1, "leaf": {"x": 10, "y": None}},
+                {"n": 2, "leaf": {"x": 20, "y": None}},
+            ],
+        },
+    )
+    assert_df_equality(observed, expected)
+
+
+def test_fill_unspecified_inner_fields_missing_sub_struct(spark: SparkSession):
+    class Sub(Schema):
+        p: Column[IntegerType]
+
+    class InnerWithSub(Schema):
+        x: Column[IntegerType]
+        sub: Column[StructType[Sub]]
+
+    class TopStructSubFull(Schema):
+        id: Column[IntegerType]
+        inner: Column[StructType[InnerWithSub]]
+
+    ds = create_partially_filled_dataset(
+        spark,
+        TopStructPartial,
+        {TopStructPartial.id: [1, 2], TopStructPartial.inner: [{"x": 10}, {"x": 20}]},
+    )
+    observed = transform_to_schema(
+        ds, TopStructSubFull, {}, fill_unspecified_inner_fields_with_nulls=True
+    )
+    expected = create_partially_filled_dataset(
+        spark,
+        TopStructSubFull,
+        {
+            TopStructSubFull.id: [1, 2],
+            TopStructSubFull.inner: [{"x": 10, "sub": None}, {"x": 20, "sub": None}],
+        },
+    )
+    assert_df_equality(observed, expected)
+
+
+def test_fill_unspecified_inner_fields_in_array(spark: SparkSession):
+    class TopArrayFull(Schema):
+        id: Column[IntegerType]
+        items: Column[ArrayType[StructType[InnerFull]]]
+
+    class TopArrayPartial(Schema):
+        id: Column[IntegerType]
+        items: Column[ArrayType[StructType[InnerPartial]]]
+
+    ds = create_partially_filled_dataset(
+        spark,
+        TopArrayPartial,
+        {
+            TopArrayPartial.id: [1, 2],
+            TopArrayPartial.items: [[{"x": 10}, {"x": 11}], [{"x": 20}]],
+        },
+    )
+    observed = transform_to_schema(ds, TopArrayFull, {}, fill_unspecified_inner_fields_with_nulls=True)
+    expected = create_partially_filled_dataset(
+        spark,
+        TopArrayFull,
+        {
+            TopArrayFull.id: [1, 2],
+            TopArrayFull.items: [
+                [{"x": 10, "y": None}, {"x": 11, "y": None}],
+                [{"x": 20, "y": None}],
+            ],
+        },
+    )
+    assert_df_equality(observed, expected)
+
+
+def test_fill_unspecified_inner_fields_in_map(spark: SparkSession):
+    class TopMapFull(Schema):
+        id: Column[IntegerType]
+        mapping: Column[MapType[StringType, StructType[InnerFull]]]
+
+    class TopMapPartial(Schema):
+        id: Column[IntegerType]
+        mapping: Column[MapType[StringType, StructType[InnerPartial]]]
+
+    ds = create_partially_filled_dataset(
+        spark,
+        TopMapPartial,
+        {
+            TopMapPartial.id: [1, 2],
+            TopMapPartial.mapping: [{"a": {"x": 10}}, {"b": {"x": 20}}],
+        },
+    )
+    observed = transform_to_schema(ds, TopMapFull, {}, fill_unspecified_inner_fields_with_nulls=True)
+    expected = create_partially_filled_dataset(
+        spark,
+        TopMapFull,
+        {
+            TopMapFull.id: [1, 2],
+            TopMapFull.mapping: [{"a": {"x": 10, "y": None}}, {"b": {"x": 20, "y": None}}],
+        },
+    )
     assert_df_equality(observed, expected)

--- a/tests/_transforms/test_transform_to_schema.py
+++ b/tests/_transforms/test_transform_to_schema.py
@@ -424,7 +424,7 @@ def test_fill_unspecified_inner_fields_skips_columns_absent_from_data(spark: Spa
         inner: Column[StructType[InnerFull]]
 
     ds = create_partially_filled_dataset(spark, IdOnly, {IdOnly.id: [1, 2]})
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         transform_to_schema(
             ds,
             TopStructFull,

--- a/tests/_transforms/test_transform_to_schema.py
+++ b/tests/_transforms/test_transform_to_schema.py
@@ -200,6 +200,7 @@ def test_transform_to_schema_parallel(spark: SparkSession):
 
 # Schemas shared across multiple fill_unspecified_inner_fields tests
 
+
 class InnerFull(Schema):
     x: Column[IntegerType]
     y: Column[IntegerType]
@@ -224,11 +225,16 @@ def test_fill_unspecified_inner_fields_simple_missing_field(spark: SparkSession)
         TopStructPartial,
         {TopStructPartial.id: [1, 2], TopStructPartial.inner: [{"x": 10}, {"x": 20}]},
     )
-    observed = transform_to_schema(ds, TopStructFull, {}, fill_unspecified_inner_fields_with_nulls=True)
+    observed = transform_to_schema(
+        ds, TopStructFull, {}, fill_unspecified_inner_fields_with_nulls=True
+    )
     expected = create_partially_filled_dataset(
         spark,
         TopStructFull,
-        {TopStructFull.id: [1, 2], TopStructFull.inner: [{"x": 10, "y": None}, {"x": 20, "y": None}]},
+        {
+            TopStructFull.id: [1, 2],
+            TopStructFull.inner: [{"x": 10, "y": None}, {"x": 20, "y": None}],
+        },
     )
     assert_df_equality(observed, expected)
 
@@ -326,7 +332,9 @@ def test_fill_unspecified_inner_fields_in_array(spark: SparkSession):
             TopArrayPartial.items: [[{"x": 10}, {"x": 11}], [{"x": 20}]],
         },
     )
-    observed = transform_to_schema(ds, TopArrayFull, {}, fill_unspecified_inner_fields_with_nulls=True)
+    observed = transform_to_schema(
+        ds, TopArrayFull, {}, fill_unspecified_inner_fields_with_nulls=True
+    )
     expected = create_partially_filled_dataset(
         spark,
         TopArrayFull,
@@ -358,7 +366,9 @@ def test_fill_unspecified_inner_fields_in_map(spark: SparkSession):
             TopMapPartial.mapping: [{"a": {"x": 10}}, {"b": {"x": 20}}],
         },
     )
-    observed = transform_to_schema(ds, TopMapFull, {}, fill_unspecified_inner_fields_with_nulls=True)
+    observed = transform_to_schema(
+        ds, TopMapFull, {}, fill_unspecified_inner_fields_with_nulls=True
+    )
     expected = create_partially_filled_dataset(
         spark,
         TopMapFull,

--- a/tests/_transforms/test_transform_to_schema.py
+++ b/tests/_transforms/test_transform_to_schema.py
@@ -379,3 +379,77 @@ def test_fill_unspecified_inner_fields_in_map(spark: SparkSession):
         },
     )
     assert_df_equality(observed, expected)
+
+
+def test_fill_unspecified_inner_fields_skips_explicitly_transformed_columns(spark: SparkSession):
+    """Line 132: columns already in transformations are skipped by auto-fill."""
+    from pyspark.sql import functions as F
+
+    class TopStructFull(Schema):
+        id: Column[IntegerType]
+        inner: Column[StructType[InnerFull]]
+
+    ds = create_partially_filled_dataset(
+        spark,
+        TopStructPartial,
+        {TopStructPartial.id: [1, 2], TopStructPartial.inner: [{"x": 10}, {"x": 20}]},
+    )
+    observed = transform_to_schema(
+        ds,
+        TopStructFull,
+        {TopStructFull.inner: F.struct(F.lit(99).alias("x"), F.lit(42).alias("y"))},
+        fill_unspecified_inner_fields_with_nulls=True,
+    )
+    expected = create_partially_filled_dataset(
+        spark,
+        TopStructFull,
+        {
+            TopStructFull.id: [1, 2],
+            TopStructFull.inner: [{"x": 99, "y": 42}, {"x": 99, "y": 42}],
+        },
+    )
+    assert_df_equality(observed, expected, ignore_nullable=True)
+
+
+def test_fill_unspecified_inner_fields_skips_columns_absent_from_data(spark: SparkSession):
+    """Line 134: top-level columns missing from the data are skipped (handled by
+    fill_unspecified_columns_with_nulls instead)."""
+
+    class IdOnly(Schema):
+        id: Column[IntegerType]
+
+    class TopStructFull(Schema):
+        id: Column[IntegerType]
+        inner: Column[StructType[InnerFull]]
+
+    ds = create_partially_filled_dataset(spark, IdOnly, {IdOnly.id: [1, 2]})
+    observed = transform_to_schema(
+        ds,
+        TopStructFull,
+        {},
+        fill_unspecified_columns_with_nulls=True,
+        fill_unspecified_inner_fields_with_nulls=True,
+    )
+    expected = create_partially_filled_dataset(spark, TopStructFull, {TopStructFull.id: [1, 2]})
+    assert_df_equality(observed, expected)
+
+
+def test_fill_unspecified_inner_fields_map_key_type_mismatch_raises(spark: SparkSession):
+    """Lines 97 + 107: map key type mismatch enters the transform_keys branch but
+    cannot fix incompatible primitive types, so validation raises TypeError."""
+
+    class TopMapIntKey(Schema):
+        id: Column[IntegerType]
+        mapping: Column[MapType[IntegerType, StructType[InnerFull]]]
+
+    class TopMapStrKey(Schema):
+        id: Column[IntegerType]
+        mapping: Column[MapType[StringType, StructType[InnerFull]]]
+
+    ds = create_partially_filled_dataset(
+        spark,
+        TopMapIntKey,
+        {TopMapIntKey.id: [1], TopMapIntKey.mapping: [{1: {"x": 10, "y": 20}}]},
+    )
+    with pytest.raises(TypeError):
+        transform_to_schema(ds, TopMapStrKey, {}, fill_unspecified_inner_fields_with_nulls=True)

--- a/tests/_transforms/test_transform_to_schema.py
+++ b/tests/_transforms/test_transform_to_schema.py
@@ -51,7 +51,7 @@ def test_transform_to_schema_with_transformation(spark: SparkSession):
 
 def test_transform_to_schema_with_missing_column(spark):
     df = create_partially_filled_dataset(spark, Person, {Person.c: [1, 2, 3]}).drop(Person.a)
-    with pytest.raises(Exception):
+    with pytest.raises(AnalysisException):
         transform_to_schema(df, PersonDifferentData, {PersonDifferentData.d: Person.c + 3})
 
     observed = transform_to_schema(

--- a/typedspark/_transforms/transform_to_schema.py
+++ b/typedspark/_transforms/transform_to_schema.py
@@ -10,7 +10,11 @@ from typedspark._core.column import Column
 from typedspark._core.dataset import DataSet
 from typedspark._schema.schema import Schema
 from typedspark._transforms.rename_duplicate_columns import RenameDuplicateColumns
-from typedspark._transforms.utils import add_nulls_for_unspecified_columns, convert_keys_to_strings
+from typedspark._transforms.utils import (
+    add_nulls_for_unspecified_columns,
+    convert_keys_to_strings,
+    add_nulls_for_unspecified_nested_fields,
+)
 
 T = TypeVar("T", bound=Schema)
 
@@ -44,6 +48,7 @@ def transform_to_schema(
     schema: Type[T],
     transformations: Optional[Dict[Column, SparkColumn]] = None,
     fill_unspecified_columns_with_nulls: bool = False,
+    fill_unspecified_inner_fields_with_nulls: bool = False,
     run_sequentially: bool = True,
 ) -> DataSet[T]:
     """On the provided DataFrame ``df``, it performs the ``transformations`` (if
@@ -68,6 +73,9 @@ def transform_to_schema(
 
     if fill_unspecified_columns_with_nulls:
         transform = add_nulls_for_unspecified_columns(transform, schema, dataframe.columns)
+
+    if fill_unspecified_inner_fields_with_nulls:
+        transform.update(add_nulls_for_unspecified_nested_fields(schema.get_structtype(), dataframe.schema, transform))
 
     transform = RenameDuplicateColumns(transform, schema, dataframe.columns)
 

--- a/typedspark/_transforms/transform_to_schema.py
+++ b/typedspark/_transforms/transform_to_schema.py
@@ -12,8 +12,8 @@ from typedspark._schema.schema import Schema
 from typedspark._transforms.rename_duplicate_columns import RenameDuplicateColumns
 from typedspark._transforms.utils import (
     add_nulls_for_unspecified_columns,
-    convert_keys_to_strings,
     add_nulls_for_unspecified_nested_fields,
+    convert_keys_to_strings,
 )
 
 T = TypeVar("T", bound=Schema)

--- a/typedspark/_transforms/transform_to_schema.py
+++ b/typedspark/_transforms/transform_to_schema.py
@@ -75,7 +75,11 @@ def transform_to_schema(
         transform = add_nulls_for_unspecified_columns(transform, schema, dataframe.columns)
 
     if fill_unspecified_inner_fields_with_nulls:
-        transform.update(add_nulls_for_unspecified_nested_fields(schema.get_structtype(), dataframe.schema, transform))
+        transform.update(
+            add_nulls_for_unspecified_nested_fields(
+                schema.get_structtype(), dataframe.schema, transform
+            )
+        )
 
     transform = RenameDuplicateColumns(transform, schema, dataframe.columns)
 

--- a/typedspark/_transforms/utils.py
+++ b/typedspark/_transforms/utils.py
@@ -1,9 +1,10 @@
 """Util functions for typedspark._transforms."""
 
 from typing import Dict, List, Optional, Type
-
 from pyspark.sql import Column as SparkColumn
-from pyspark.sql.functions import lit
+from pyspark.sql.functions import lit, transform, transform_values, transform_keys, col
+from pyspark.sql.types import StructType, ArrayType, MapType
+from typedspark._core.validate_schema import unpack_schema
 
 from typedspark._core.column import Column
 from typedspark._schema.schema import Schema
@@ -44,3 +45,98 @@ def convert_keys_to_strings(
         )
 
     return _transformations
+
+def _fill_missing_fields(
+    schema_dtype,
+    data_dtype,
+    current: SparkColumn,
+) -> Optional[SparkColumn]:
+    """Return `current` rebuilt with any schema fields absent from the data added as null.
+    Works on column expressions (not dotted-path strings) so it can recurse into array
+    and map elements via higher-order function lambdas. Returns None when no changes are
+    needed.
+    """
+    if schema_dtype == data_dtype:
+        return None
+    if isinstance(schema_dtype, StructType) and isinstance(data_dtype, StructType):
+        data_dict = unpack_schema(data_dtype)
+        expression = current
+        changed = False
+        for schema_field in schema_dtype.fields:
+            if schema_field.name not in data_dict:
+                expression = expression.withField(
+                    schema_field.name, lit(None).cast(schema_field.dataType)
+                )
+                changed = True
+                continue
+            inner = _fill_missing_fields(
+                schema_field.dataType,
+                data_dict[schema_field.name].dataType,
+                current.getField(schema_field.name),
+            )
+            if inner is not None:
+                expression = expression.withField(schema_field.name, inner)
+                changed = True
+        return expression if changed else None
+    if isinstance(schema_dtype, ArrayType) and isinstance(data_dtype, ArrayType):
+        element_schema = schema_dtype.elementType
+        element_data = data_dtype.elementType
+        return transform(
+            current,
+            lambda elem: _fill_missing_fields_or_keep(element_schema, element_data, elem),
+        )
+    if isinstance(schema_dtype, MapType) and isinstance(data_dtype, MapType):
+        key_schema = schema_dtype.keyType
+        key_data = data_dtype.keyType
+        value_schema = schema_dtype.valueType
+        value_data = data_dtype.valueType
+        expression = current
+        if key_schema != key_data:
+            expression = transform_keys(
+                expression,
+                lambda k, _v: _fill_missing_fields_or_keep(key_schema, key_data, k),
+            )
+        if value_schema != value_data:
+            expression = transform_values(
+                expression,
+                lambda _k, v: _fill_missing_fields_or_keep(value_schema, value_data, v),
+            )
+        return expression
+    return None
+
+
+def _fill_missing_fields_or_keep(schema_dtype, data_dtype, current: SparkColumn) -> SparkColumn:
+    filled = _fill_missing_fields(schema_dtype, data_dtype, current)
+    return current if filled is None else filled
+
+
+def add_nulls_for_unspecified_nested_fields(
+    schema_struct: StructType,
+    data_struct: StructType,
+    transformations: Dict[str, SparkColumn] | None = None,
+) -> Dict[str, SparkColumn]:
+    """
+    For each top-level column present in both `schema_struct` and `data_struct` whose
+    type differs, produces a replacement expression that keeps all existing values and
+    adds any schema fields missing from the data as null. Handles structs, arrays of
+    structs, and maps of structs, recursively.
+    """
+    schema_dict = unpack_schema(schema_struct)
+    data_dict = unpack_schema(data_struct)
+    transformed_col_names = transformations or dict()
+    result: Dict[str, SparkColumn] = dict()
+    for _, schema_field in schema_dict.items():
+        if schema_field.name in transformed_col_names:
+            continue
+        if schema_field.name not in data_dict:
+            continue
+        patched = _fill_missing_fields(
+            schema_field.dataType,
+            data_dict[schema_field.name].dataType,
+            col(schema_field.name),
+        )
+        if patched is not None:
+            result[schema_field.name] = patched
+    return result
+
+

--- a/typedspark/_transforms/utils.py
+++ b/typedspark/_transforms/utils.py
@@ -47,6 +47,7 @@ def convert_keys_to_strings(
 
     return _transformations
 
+
 def _fill_missing_fields(
     schema_dtype,
     data_dtype,
@@ -139,5 +140,3 @@ def add_nulls_for_unspecified_nested_fields(
         if patched is not None:
             result[schema_field.name] = patched
     return result
-
-

--- a/typedspark/_transforms/utils.py
+++ b/typedspark/_transforms/utils.py
@@ -109,7 +109,7 @@ def _fill_missing_fields(
     return None
 
 
-def _fill_missing_fields_or_keep(schema_dtype, data_dtype, current: SparkColumn) -> SparkColumn:
+def _fill_missing_fields_or_keep(schema_dtype: DataType, data_dtype: DataType, current: SparkColumn) -> SparkColumn:
     filled = _fill_missing_fields(schema_dtype, data_dtype, current)
     return current if filled is None else filled
 

--- a/typedspark/_transforms/utils.py
+++ b/typedspark/_transforms/utils.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Type
 
 from pyspark.sql import Column as SparkColumn
 from pyspark.sql.functions import col, lit, transform, transform_keys, transform_values
-from pyspark.sql.types import ArrayType, MapType, StructType
+from pyspark.sql.types import ArrayType, DataType, MapType, StructType
 
 from typedspark._core.column import Column
 from typedspark._core.validate_schema import unpack_schema
@@ -53,7 +53,9 @@ def _fill_missing_fields(
     data_dtype: DataType,
     current: SparkColumn,
 ) -> Optional[SparkColumn]:
-    """Return `current` rebuilt with any schema fields absent from the data added as null.
+    """Return `current` rebuilt with any schema fields absent from the data added as
+    null.
+
     Works on column expressions (not dotted-path strings) so it can recurse into array
     and map elements via higher-order function lambdas. Returns None when no changes are
     needed.
@@ -109,7 +111,9 @@ def _fill_missing_fields(
     return None
 
 
-def _fill_missing_fields_or_keep(schema_dtype: DataType, data_dtype: DataType, current: SparkColumn) -> SparkColumn:
+def _fill_missing_fields_or_keep(
+    schema_dtype: DataType, data_dtype: DataType, current: SparkColumn
+) -> SparkColumn:
     filled = _fill_missing_fields(schema_dtype, data_dtype, current)
     return current if filled is None else filled
 
@@ -119,11 +123,11 @@ def add_nulls_for_unspecified_nested_fields(
     data_struct: StructType,
     transformations: Dict[str, SparkColumn] | None = None,
 ) -> Dict[str, SparkColumn]:
-    """
-    For each top-level column present in both `schema_struct` and `data_struct` whose
+    """For each top-level column present in both `schema_struct` and `data_struct` whose
     type differs, produces a replacement expression that keeps all existing values and
-    adds any schema fields missing from the data as null. Handles structs, arrays of
-    structs, and maps of structs, recursively.
+    adds any schema fields missing from the data as null.
+
+    Handles structs, arrays of structs, and maps of structs, recursively.
     """
     schema_dict = unpack_schema(schema_struct)
     data_dict = unpack_schema(data_struct)

--- a/typedspark/_transforms/utils.py
+++ b/typedspark/_transforms/utils.py
@@ -83,6 +83,8 @@ def _fill_missing_fields(
     if isinstance(schema_dtype, ArrayType) and isinstance(data_dtype, ArrayType):
         element_schema = schema_dtype.elementType
         element_data = data_dtype.elementType
+        if _fill_missing_fields(element_schema, element_data, col("_")) is None:
+            return None
         return transform(
             current,
             lambda elem: _fill_missing_fields_or_keep(element_schema, element_data, elem),

--- a/typedspark/_transforms/utils.py
+++ b/typedspark/_transforms/utils.py
@@ -49,8 +49,8 @@ def convert_keys_to_strings(
 
 
 def _fill_missing_fields(
-    schema_dtype,
-    data_dtype,
+    schema_dtype: DataType,
+    data_dtype: DataType,
     current: SparkColumn,
 ) -> Optional[SparkColumn]:
     """Return `current` rebuilt with any schema fields absent from the data added as null.

--- a/typedspark/_transforms/utils.py
+++ b/typedspark/_transforms/utils.py
@@ -85,8 +85,6 @@ def _fill_missing_fields(
     if isinstance(schema_dtype, ArrayType) and isinstance(data_dtype, ArrayType):
         element_schema = schema_dtype.elementType
         element_data = data_dtype.elementType
-        if _fill_missing_fields(element_schema, element_data, col("_")) is None:
-            return None
         return transform(
             current,
             lambda elem: _fill_missing_fields_or_keep(element_schema, element_data, elem),

--- a/typedspark/_transforms/utils.py
+++ b/typedspark/_transforms/utils.py
@@ -3,11 +3,11 @@
 from typing import Any, Dict, List, Optional, Type
 
 from pyspark.sql import Column as SparkColumn
-from pyspark.sql.functions import lit, transform, transform_values, transform_keys, col
-from pyspark.sql.types import StructType, ArrayType, MapType
-from typedspark._core.validate_schema import unpack_schema
+from pyspark.sql.functions import col, lit, transform, transform_keys, transform_values
+from pyspark.sql.types import ArrayType, MapType, StructType
 
 from typedspark._core.column import Column
+from typedspark._core.validate_schema import unpack_schema
 from typedspark._schema.schema import Schema
 
 


### PR DESCRIPTION
Adds a new fill_unspecified_inner_fields_with_nulls parameter to transform_to_schema that fills missing fields inside nested types with null.

When the source data has a struct, array-of-struct, or map-of-struct column whose schema is a subset of the struct of the target schema , the new option recursively adds the missing fields as null rather than raising a validation error.

Issue: https://github.com/kaiko-ai/typedspark/issues/580
