### PR TITLE
Add `DataSetWith[Protocol]` for protocol-style schema variance

### DIFF
--- a/tests/_core/test_dataset.py
+++ b/tests/_core/test_dataset.py
@@ -8,7 +8,7 @@ from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql import functions as F
 from pyspark.sql.types import LongType, StringType, TimestampType
 
-from typedspark import Column, DataSet, DataSetExtends, Schema
+from typedspark import Column, DataSet, DataSetWith, Schema
 from typedspark._core.dataset import DataSetImplements
 from typedspark._utils.create_dataset import create_empty_dataset
 
@@ -295,17 +295,17 @@ class _AgeProtocol(Schema, Protocol):
 
 
 def test_dataset_is_subclass_of_dataset_extends(spark: SparkSession):
-    """``DataSet[T]`` must be a subclass of ``DataSetExtends`` so that callers can pass it
-    to functions annotated as ``DataSetExtends[Protocol]`` for any compatible ``Protocol``."""
+    """``DataSet[T]`` must be a subclass of ``DataSetWith`` so that callers can pass it
+    to functions annotated as ``DataSetWith[Protocol]`` for any compatible ``Protocol``."""
     df = create_empty_dataset(spark, A)
-    assert isinstance(df, DataSetExtends)
+    assert isinstance(df, DataSetWith)
 
 
 def test_dataset_extends_accepts_extra_columns(spark: SparkSession):
-    """``DataSetExtends[Protocol]`` validates the declared columns and tolerates extras."""
+    """``DataSetWith[Protocol]`` validates the declared columns and tolerates extras."""
     d = dict(a=[1, 2, 3], b=["a", "b", "c"], extra=[7, 8, 9])
     df = create_dataframe(spark, d)
-    ds = DataSetExtends[_AgeProtocol](df)
+    ds = DataSetWith[_AgeProtocol](df)
     assert set(ds.columns) == {"a", "b", "extra"}
     assert ds.typedspark_schema == _AgeProtocol
 
@@ -315,7 +315,7 @@ def test_dataset_extends_still_requires_declared_columns(spark: SparkSession):
     d = dict(b=["a", "b", "c"])
     df = create_dataframe(spark, d)
     with pytest.raises(TypeError):
-        DataSetExtends[_AgeProtocol](df)
+        DataSetWith[_AgeProtocol](df)
 
 
 def test_dataset_extends_still_validates_dtypes(spark: SparkSession):
@@ -323,27 +323,27 @@ def test_dataset_extends_still_validates_dtypes(spark: SparkSession):
     d = dict(a=["x", "y", "z"], b=["a", "b", "c"])
     df = create_dataframe(spark, d)
     with pytest.raises(TypeError):
-        DataSetExtends[_AgeProtocol](df)
+        DataSetWith[_AgeProtocol](df)
 
 
 def test_dataset_extends_underscored_columns_are_dropped(spark: SparkSession):
     """Columns starting with ``__`` are silently ignored (consistent with ``DataSet``)."""
     d = {"a": [1, 2, 3], "__hidden": [1, 2, 3]}
     df = create_dataframe(spark, d)
-    DataSetExtends[_AgeProtocol](df)
+    DataSetWith[_AgeProtocol](df)
 
 
 def test_dataset_extends_unparameterized_is_not_instantiable(spark: SparkSession):
-    """Calling ``DataSetExtends`` without a schema parameter does nothing useful;
+    """Calling ``DataSetWith`` without a schema parameter does nothing useful;
     the resulting object is just the input DataFrame mixed in, with no validation."""
     df = create_empty_dataset(spark, A)
     # No exception, but no validation either: this mirrors ``DataSet(df)``.
-    DataSetExtends(df)
+    DataSetWith(df)
 
 
 def test_dataset_does_not_relax(spark: SparkSession):
     """``DataSet`` validation must remain strict even though it inherits from
-    ``DataSetExtends``."""
+    ``DataSetWith``."""
     d = dict(a=[1, 2, 3], b=["a", "b", "c"], c=[1, 2, 3])
     df = create_dataframe(spark, d)
     with pytest.raises(TypeError):
@@ -352,10 +352,10 @@ def test_dataset_does_not_relax(spark: SparkSession):
 
 def test_dataset_extends_in_function_annotation(spark: SparkSession):
     """``DataSet[A]`` (which has columns ``a`` and ``b``) should be usable as a
-    ``DataSetExtends[_AgeProtocol]`` (which only declares ``a``) because ``A``
+    ``DataSetWith[_AgeProtocol]`` (which only declares ``a``) because ``A``
     structurally extends ``_AgeProtocol``."""
 
-    def get_a(df: DataSetExtends[_AgeProtocol]) -> DataSet[_AgeProtocol]:
+    def get_a(df: DataSetWith[_AgeProtocol]) -> DataSet[_AgeProtocol]:
         return DataSet[_AgeProtocol](df.select(_AgeProtocol.a))
 
     full = create_empty_dataset(spark, A)

--- a/tests/_core/test_dataset.py
+++ b/tests/_core/test_dataset.py
@@ -1,5 +1,5 @@
 import functools
-from typing import cast
+from typing import Protocol, cast
 
 import pandas as pd
 import pytest
@@ -8,7 +8,7 @@ from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql import functions as F
 from pyspark.sql.types import LongType, StringType, TimestampType
 
-from typedspark import Column, DataSet, Schema
+from typedspark import Column, DataSet, DataSetExtends, Schema
 from typedspark._core.dataset import DataSetImplements
 from typedspark._utils.create_dataset import create_empty_dataset
 
@@ -288,3 +288,33 @@ def test_resetting_of_schema_annotations(spark: SparkSession):
     # and then to None again
     a = DataSet(df)
     assert a._schema_annotations is None
+
+
+class _AgeProtocol(Schema, Protocol):
+    a: Column[LongType]
+
+
+def test_dataset_is_subclass_of_dataset_extends(spark: SparkSession):
+    """``DataSet[T]`` must be a subclass of ``DataSetExtends`` so that callers can pass it
+    to functions annotated as ``DataSetExtends[Protocol]`` for any compatible ``Protocol``."""
+    df = create_empty_dataset(spark, A)
+    assert isinstance(df, DataSetExtends)
+
+
+def test_dataset_extends_is_not_instantiable():
+    """``DataSetExtends`` is solely a type annotation; it must not be instantiated directly."""
+    with pytest.raises(NotImplementedError):
+        DataSetExtends()
+
+
+def test_dataset_extends_in_function_annotation(spark: SparkSession):
+    """``DataSet[A]`` (which has columns ``a`` and ``b``) should be usable as a
+    ``DataSetExtends[_AgeProtocol]`` (which only declares ``a``) because ``A``
+    structurally extends ``_AgeProtocol``."""
+
+    def get_a(df: DataSetExtends[_AgeProtocol]) -> DataSet[_AgeProtocol]:
+        return DataSet[_AgeProtocol](df.select(_AgeProtocol.a))
+
+    full = create_empty_dataset(spark, A)
+    projected = get_a(full)
+    assert projected.columns == ["a"]

--- a/tests/_core/test_dataset.py
+++ b/tests/_core/test_dataset.py
@@ -301,10 +301,53 @@ def test_dataset_is_subclass_of_dataset_extends(spark: SparkSession):
     assert isinstance(df, DataSetExtends)
 
 
-def test_dataset_extends_is_not_instantiable():
-    """``DataSetExtends`` is solely a type annotation; it must not be instantiated directly."""
-    with pytest.raises(NotImplementedError):
-        DataSetExtends()
+def test_dataset_extends_accepts_extra_columns(spark: SparkSession):
+    """``DataSetExtends[Protocol]`` validates the declared columns and tolerates extras."""
+    d = dict(a=[1, 2, 3], b=["a", "b", "c"], extra=[7, 8, 9])
+    df = create_dataframe(spark, d)
+    ds = DataSetExtends[_AgeProtocol](df)
+    assert set(ds.columns) == {"a", "b", "extra"}
+    assert ds.typedspark_schema == _AgeProtocol
+
+
+def test_dataset_extends_still_requires_declared_columns(spark: SparkSession):
+    """A column declared on the protocol but missing from the data still raises."""
+    d = dict(b=["a", "b", "c"])
+    df = create_dataframe(spark, d)
+    with pytest.raises(TypeError):
+        DataSetExtends[_AgeProtocol](df)
+
+
+def test_dataset_extends_still_validates_dtypes(spark: SparkSession):
+    """A column whose dtype doesn't match the protocol still raises."""
+    d = dict(a=["x", "y", "z"], b=["a", "b", "c"])
+    df = create_dataframe(spark, d)
+    with pytest.raises(TypeError):
+        DataSetExtends[_AgeProtocol](df)
+
+
+def test_dataset_extends_underscored_columns_are_dropped(spark: SparkSession):
+    """Columns starting with ``__`` are silently ignored (consistent with ``DataSet``)."""
+    d = {"a": [1, 2, 3], "__hidden": [1, 2, 3]}
+    df = create_dataframe(spark, d)
+    DataSetExtends[_AgeProtocol](df)
+
+
+def test_dataset_extends_unparameterized_is_not_instantiable(spark: SparkSession):
+    """Calling ``DataSetExtends`` without a schema parameter does nothing useful;
+    the resulting object is just the input DataFrame mixed in, with no validation."""
+    df = create_empty_dataset(spark, A)
+    # No exception, but no validation either: this mirrors ``DataSet(df)``.
+    DataSetExtends(df)
+
+
+def test_dataset_does_not_relax(spark: SparkSession):
+    """``DataSet`` validation must remain strict even though it inherits from
+    ``DataSetExtends``."""
+    d = dict(a=[1, 2, 3], b=["a", "b", "c"], c=[1, 2, 3])
+    df = create_dataframe(spark, d)
+    with pytest.raises(TypeError):
+        DataSet[A](df)
 
 
 def test_dataset_extends_in_function_annotation(spark: SparkSession):

--- a/tests/_typing/cases.py
+++ b/tests/_typing/cases.py
@@ -1,0 +1,77 @@
+# mypy: warn_unused_ignores=True
+# pyright: reportUnnecessaryTypeIgnoreComment=error
+"""Type-checker assertions for ``DataSet`` and ``DataSetWith``.
+
+This module is intentionally **not** named ``test_*``: pytest does not collect
+it. It exists to be exercised by ``mypy`` and ``pyright`` (which both run on
+the whole repo in CI):
+
+* Positive cases use :func:`typing_extensions.assert_type` to lock in inferred
+  types. If the inferred type ever changes, both checkers fail.
+* Negative cases mark expected errors with ``# type: ignore[<code>]``. The
+  file-level pragmas above turn unused ignores into errors, so if a line ever
+  stops being a type error (e.g. because variance was relaxed), the ignore
+  becomes "unused" and CI fails.
+
+The module is import-safe — it never executes anything that touches Spark — so
+mypy/pyright can analyze it without a runtime environment.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from pyspark.sql.types import LongType, StringType
+from typing_extensions import assert_type
+
+from typedspark import Column, DataSet, DataSetWith, Schema
+
+
+class _Age(Schema, Protocol):
+    age: Column[LongType]
+
+
+class _Person(Schema):
+    name: Column[StringType]
+    age: Column[LongType]
+
+
+def _person() -> DataSet[_Person]:  # pragma: no cover - type-only helper
+    raise NotImplementedError
+
+
+# ---------- positive cases ----------
+
+# A ``DataSet[T]`` is a ``DataSetWith[T]``: this assignment must type-check.
+_self: DataSetWith[_Person] = _person()
+
+# Covariance: ``_Person`` structurally implements the ``_Age`` protocol, so
+# ``DataSet[_Person]`` must be assignable to ``DataSetWith[_Age]``.
+_widened: DataSetWith[_Age] = _person()
+
+
+def needs_age(df: DataSetWith[_Age]) -> DataSet[_Age]:
+    """A function written against the wider protocol can take any DataSet whose
+    schema covers ``_Age``."""
+    return DataSet[_Age](df.select(_Age.age))
+
+
+# Calling the function with a more specific DataSet must type-check.
+_projected = needs_age(_person())
+assert_type(_projected, DataSet[_Age])
+
+
+# ---------- negative cases ----------
+
+# ``DataSet`` is invariant in its schema. Even though ``_Person`` extends
+# ``_Age`` structurally, ``DataSet[_Person]`` is **not** a ``DataSet[_Age]``;
+# users must opt into the wider protocol via ``DataSetWith``.
+_strict: DataSet[_Age] = _person()  # type: ignore[assignment]
+
+
+def needs_age_strict(df: DataSet[_Age]) -> None:
+    """Strict variant — only accepts ``DataSet[_Age]`` exactly."""
+
+
+# Passing a ``DataSet[_Person]`` to the strict signature must error.
+needs_age_strict(_person())  # type: ignore[arg-type]

--- a/typedspark/__init__.py
+++ b/typedspark/__init__.py
@@ -2,7 +2,7 @@
 
 from typedspark._core.column import Column
 from typedspark._core.column_meta import ColumnMeta
-from typedspark._core.dataset import DataSet, DataSetExtends, DataSetImplements
+from typedspark._core.dataset import DataSet, DataSetImplements, DataSetWith
 from typedspark._core.datatypes import (
     ArrayType,
     DayTimeIntervalType,
@@ -34,7 +34,7 @@ __all__ = [
     "Database",
     "Databases",
     "DataSet",
-    "DataSetExtends",
+    "DataSetWith",
     "DayTimeIntervalType",
     "DecimalType",
     "IntervalType",

--- a/typedspark/__init__.py
+++ b/typedspark/__init__.py
@@ -2,7 +2,7 @@
 
 from typedspark._core.column import Column
 from typedspark._core.column_meta import ColumnMeta
-from typedspark._core.dataset import DataSet, DataSetImplements
+from typedspark._core.dataset import DataSet, DataSetExtends, DataSetImplements
 from typedspark._core.datatypes import (
     ArrayType,
     DayTimeIntervalType,
@@ -34,6 +34,7 @@ __all__ = [
     "Database",
     "Databases",
     "DataSet",
+    "DataSetExtends",
     "DayTimeIntervalType",
     "DecimalType",
     "IntervalType",

--- a/typedspark/_core/dataset.py
+++ b/typedspark/_core/dataset.py
@@ -439,15 +439,15 @@ class DataSetImplements(DataFrame, Generic[_Protocol, _Implementation]):
         return res  # pragma: no cover
 
 
-class DataSetExtends(DataSetImplements[_Protocol, _Protocol]):
-    """``DataSetExtends`` allows us to define functions such as:
+class DataSetWith(DataSetImplements[_Protocol, _Protocol]):
+    """``DataSetWith`` allows us to define functions such as:
 
     .. code-block:: python
 
         class Age(Schema, Protocol):
             age: Column[LongType]
 
-        def get_age(df: DataSetExtends[Age]) -> DataSet[Age]:
+        def get_age(df: DataSetWith[Age]) -> DataSet[Age]:
             return DataSet[Age](df.select(Age.age))
 
     Such a function:
@@ -458,26 +458,26 @@ class DataSetExtends(DataSetImplements[_Protocol, _Protocol]):
     2. Returns a ``DataSet[Age]``: typically the projection of the input to ``Age``'s
        columns.
 
-    A ``DataSetExtends`` can also be constructed directly from a ``DataFrame`` whose
+    A ``DataSetWith`` can also be constructed directly from a ``DataFrame`` whose
     schema is a superset of ``_Protocol``:
 
     .. code-block:: python
 
-        ds = DataSetExtends[Age](df_with_extra_columns)
+        ds = DataSetWith[Age](df_with_extra_columns)
 
     Construction validates that ``df`` contains every column declared on ``_Protocol``
     (with matching dtypes); columns not declared on ``_Protocol`` are tolerated and
     pass through unchanged.
     """
 
-    def __new__(cls, dataframe: DataFrame) -> DataSetExtends[_Protocol]:
+    def __new__(cls, dataframe: DataFrame) -> DataSetWith[_Protocol]:
         """``__new__()`` instantiates the object (prior to ``__init__()``).
 
         Like :class:`DataSet`, the underlying ``DataFrame`` is reclassed in place; the
         difference is that schema validation here tolerates columns absent from the
         declared protocol.
         """
-        dataframe = cast(DataSetExtends, dataframe)
+        dataframe = cast(DataSetWith, dataframe)
         attach_mixin(dataframe, cls)
 
         # reset _schema_annotations in case it was inherited from the source DataFrame
@@ -494,7 +494,7 @@ class DataSetExtends(DataSetImplements[_Protocol, _Protocol]):
         pass
 
     def __class_getitem__(cls, item):
-        """Allows us to define a schema for the ``DataSetExtends``.
+        """Allows us to define a schema for the ``DataSetWith``.
 
         TypeVar parameters (e.g. when this class is itself subclassed with a generic
         parameter) are forwarded to ``Generic`` so the standard parameterization
@@ -527,9 +527,9 @@ class DataSetExtends(DataSetImplements[_Protocol, _Protocol]):
                 self.schema[field.name].metadata = field.metadata
 
 
-class DataSet(DataSetExtends[_Schema]):
+class DataSet(DataSetWith[_Schema]):
     # pylint: disable=missing-function-docstring,invalid-name
-    # ``DataSetExtends[_Schema]`` is opaque to astroid because of the custom
+    # ``DataSetWith[_Schema]`` is opaque to astroid because of the custom
     # ``__class_getitem__``, so pylint cannot walk past it to find that the method
     # overrides below override DataFrame's documented methods. The disables below
     # restore the behavior we get on DataSetImplements (whose direct DataFrame parent
@@ -548,8 +548,8 @@ class DataSet(DataSetExtends[_Schema]):
             return df
 
     Functions that should accept ``DataSet[T]`` for any ``T`` whose schema structurally
-    extends a given protocol can use :class:`DataSetExtends` as their parameter
-    annotation; ``DataSet[T]`` is a subclass of ``DataSetExtends[T]``, and ``_Protocol``
+    extends a given protocol can use :class:`DataSetWith` as their parameter
+    annotation; ``DataSet[T]`` is a subclass of ``DataSetWith[T]``, and ``_Protocol``
     is covariant, so callers can pass a ``DataSet`` of any compatible schema.
     """
 

--- a/typedspark/_core/dataset.py
+++ b/typedspark/_core/dataset.py
@@ -458,22 +458,82 @@ class DataSetExtends(DataSetImplements[_Protocol, _Protocol]):
     2. Returns a ``DataSet[Age]``: typically the projection of the input to ``Age``'s
        columns.
 
-    Like :class:`DataSetImplements`, ``DataSetExtends`` is solely used as a type
-    annotation; it is never initialized directly.
+    A ``DataSetExtends`` can also be constructed directly from a ``DataFrame`` whose
+    schema is a superset of ``_Protocol``:
+
+    .. code-block:: python
+
+        ds = DataSetExtends[Age](df_with_extra_columns)
+
+    Construction validates that ``df`` contains every column declared on ``_Protocol``
+    (with matching dtypes); columns not declared on ``_Protocol`` are tolerated and
+    pass through unchanged.
     """
 
-    def __new__(cls, *args, **kwargs):
-        raise NotImplementedError(
-            "DataSetExtends should solely be used as a type annotation, it is never initialized."
+    def __new__(cls, dataframe: DataFrame) -> DataSetExtends[_Protocol]:
+        """``__new__()`` instantiates the object (prior to ``__init__()``).
+
+        Like :class:`DataSet`, the underlying ``DataFrame`` is reclassed in place; the
+        difference is that schema validation here tolerates columns absent from the
+        declared protocol.
+        """
+        dataframe = cast(DataSetExtends, dataframe)
+        attach_mixin(dataframe, cls)
+
+        # reset _schema_annotations in case it was inherited from the source DataFrame
+        dataframe._schema_annotations = None  # type: ignore
+
+        if "_schema_annotations" in cls.__dict__:
+            dataframe._schema_annotations = cls._schema_annotations  # type: ignore
+            dataframe._validate_schema()
+            dataframe._add_schema_metadata()
+
+        return dataframe  # type: ignore
+
+    def __init__(self, dataframe: DataFrame):
+        pass
+
+    def __class_getitem__(cls, item):
+        """Allows us to define a schema for the ``DataSetExtends``.
+
+        TypeVar parameters (e.g. when this class is itself subclassed with a generic
+        parameter) are forwarded to ``Generic`` so the standard parameterization
+        machinery applies and no schema is baked into the subclass.
+        """
+        if isinstance(item, TypeVar):
+            return super().__class_getitem__(item)  # type: ignore[misc]
+        subclass_name = f"{cls.__name__}[{item.__name__}]"
+        subclass = type(subclass_name, (cls,), {"_schema_annotations": item})
+        return subclass
+
+    def _validate_schema(self) -> None:
+        """Validates the schema while tolerating columns not declared by ``_Protocol``."""
+        validate_schema(
+            self._schema_annotations.get_structtype(),
+            deepcopy(self.schema),
+            self._schema_annotations.get_schema_name(),
+            ignore_extra_columns=True,
         )
 
-    def __init__(self):  # pragma: no cover - DataSetExtends is never instantiated.
-        raise NotImplementedError(
-            "DataSetExtends should solely be used as a type annotation, it is never initialized."
-        )
+    def _add_schema_metadata(self) -> None:
+        """Adds the ``ColumnMeta`` comments as metadata for the declared columns.
+
+        Columns present on the DataFrame but not declared on the protocol keep their
+        existing metadata.
+        """
+        observed = set(self.schema.fieldNames())
+        for field in self._schema_annotations.get_structtype().fields:
+            if field.name in observed:
+                self.schema[field.name].metadata = field.metadata
 
 
 class DataSet(DataSetExtends[_Schema]):
+    # pylint: disable=missing-function-docstring,invalid-name
+    # ``DataSetExtends[_Schema]`` is opaque to astroid because of the custom
+    # ``__class_getitem__``, so pylint cannot walk past it to find that the method
+    # overrides below override DataFrame's documented methods. The disables below
+    # restore the behavior we get on DataSetImplements (whose direct DataFrame parent
+    # astroid does follow).
     """``DataSet`` subclasses pyspark ``DataFrame`` and hence has all the same
     functionality, with in addition the possibility to define a schema.
 

--- a/typedspark/_core/dataset.py
+++ b/typedspark/_core/dataset.py
@@ -439,7 +439,41 @@ class DataSetImplements(DataFrame, Generic[_Protocol, _Implementation]):
         return res  # pragma: no cover
 
 
-class DataSet(DataSetImplements[_Schema, _Schema]):
+class DataSetExtends(DataSetImplements[_Protocol, _Protocol]):
+    """``DataSetExtends`` allows us to define functions such as:
+
+    .. code-block:: python
+
+        class Age(Schema, Protocol):
+            age: Column[LongType]
+
+        def get_age(df: DataSetExtends[Age]) -> DataSet[Age]:
+            return DataSet[Age](df.select(Age.age))
+
+    Such a function:
+
+    1. Accepts any ``DataSet[T]`` whose schema ``T`` structurally implements ``Age``,
+       even when ``T`` declares additional columns. This is checked at lint time
+       (since ``_Protocol`` is covariant).
+    2. Returns a ``DataSet[Age]``: typically the projection of the input to ``Age``'s
+       columns.
+
+    Like :class:`DataSetImplements`, ``DataSetExtends`` is solely used as a type
+    annotation; it is never initialized directly.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        raise NotImplementedError(
+            "DataSetExtends should solely be used as a type annotation, it is never initialized."
+        )
+
+    def __init__(self):  # pragma: no cover - DataSetExtends is never instantiated.
+        raise NotImplementedError(
+            "DataSetExtends should solely be used as a type annotation, it is never initialized."
+        )
+
+
+class DataSet(DataSetExtends[_Schema]):
     """``DataSet`` subclasses pyspark ``DataFrame`` and hence has all the same
     functionality, with in addition the possibility to define a schema.
 
@@ -452,6 +486,11 @@ class DataSet(DataSetImplements[_Schema, _Schema]):
         def foo(df: DataSet[Person]) -> DataSet[Person]:
             # do stuff
             return df
+
+    Functions that should accept ``DataSet[T]`` for any ``T`` whose schema structurally
+    extends a given protocol can use :class:`DataSetExtends` as their parameter
+    annotation; ``DataSet[T]`` is a subclass of ``DataSetExtends[T]``, and ``_Protocol``
+    is covariant, so callers can pass a ``DataSet`` of any compatible schema.
     """
 
     def __new__(cls, dataframe: DataFrame) -> DataSet[_Schema]:

--- a/typedspark/_core/validate_schema.py
+++ b/typedspark/_core/validate_schema.py
@@ -8,11 +8,22 @@ from typedspark._utils.create_dataset_from_structtype import create_schema_from_
 
 
 def validate_schema(
-    structtype_expected: StructType, structtype_observed: StructType, schema_name: str
+    structtype_expected: StructType,
+    structtype_observed: StructType,
+    schema_name: str,
+    ignore_extra_columns: bool = False,
 ) -> None:
-    """Checks whether the expected and the observed StructType match."""
+    """Checks whether the expected and the observed StructType match.
+
+    When ``ignore_extra_columns`` is ``True``, columns present in the observed
+    schema but not in the expected schema are silently dropped before
+    validation. Columns missing from the observed schema still raise.
+    """
     expected = unpack_schema(structtype_expected)
     observed = unpack_schema(structtype_observed)
+
+    if ignore_extra_columns:
+        observed = {name: field for name, field in observed.items() if name in expected}
 
     check_names(expected, observed, schema_name)
     check_dtypes(expected, observed, schema_name)


### PR DESCRIPTION
## Summary

Adds a new `DataSetWith[Protocol]` type that lets functions accept any `DataSet[T]` whose schema structurally extends the declared protocol — both at lint time (via covariance) and at runtime (with extra columns tolerated):

```python
from typing import Protocol
from typedspark import Column, DataSet, DataSetWith, Schema
from pyspark.sql.types import LongType, StringType

class Age(Schema, Protocol):
    age: Column[LongType]

class Person(Schema):
    name: Column[StringType]
    age: Column[LongType]

# Lint-time variance: DataSet[Person] is assignable to DataSetWith[Age]
def get_age(df: DataSetWith[Age]) -> DataSet[Age]:
    return DataSet[Age](df.select(Age.age))

person: DataSet[Person] = ...
get_age(person)  # OK: Person structurally implements Age

# Runtime construction: extra columns tolerated
ds = DataSetWith[Age](df_with_extra_columns)  # validates Age's columns, leaves extras alone
```

`DataSet` keeps its strict semantics (extras still raise on `DataSet[Schema](df)`).

Closes #623.

### Lint-time vs. runtime behavior

| | `DataSet[Schema](df)` | `DataSetWith[Schema](df)` |
| --- | --- | --- |
| Missing declared column | raises `TypeError` | raises `TypeError` |
| Wrong dtype on declared column | raises `TypeError` | raises `TypeError` |
| Extra undeclared column | raises `TypeError` | accepted, passes through |
| `DataSet[Bigger]` assignable as `..[Smaller]`? | no (invariant) | yes (covariant in `_Protocol`) |

### Implementation notes

* `DataSetWith` sits between `DataSetImplements[_Protocol, _Protocol]` and `DataSet[_Schema]` in the inheritance chain. `_Protocol` is covariant, so `DataSet[Specific] <: DataSetWith[Protocol]` whenever `Specific` structurally implements `Protocol`.
* `DataSetWith` has its own `__new__` / `__class_getitem__` / `_validate_schema`. Validation routes through a new `validate_schema(..., ignore_extra_columns=True)` parameter; `DataSet._validate_schema` overrides it to keep the strict path.
* `DataSetWith[_Schema]` is opaque to astroid because of the custom `__class_getitem__`, so pylint can no longer walk through to find that `DataSet`'s method overrides come from `DataFrame`. A class-level `# pylint: disable=missing-function-docstring,invalid-name` on `DataSet` restores the same behavior we get on `DataSetImplements` (whose direct `DataFrame` parent astroid does follow). The disable is documented inline.

### CI-enforced type tests

`tests/_typing/cases.py` is a non-pytest module exercised by `mypy` and `pyright` in the existing lint job. It contains:

* **Positive cases** — `assert_type` calls that lock in inferred types. If the inferred type drifts, both checkers fail.
* **Negative cases** — `# type: ignore[<code>]` markers on lines that *must* be type errors. File-level pragmas turn unused ignores into errors (`# mypy: warn_unused_ignores=True`, `# pyright: reportUnnecessaryTypeIgnoreComment=error`); if a line ever stops being a type error (e.g. because variance was relaxed), the ignore becomes "unused" and CI fails.

The existing `mypy .` and `pyright .` invocations in `.github/workflows/build.yml` pick up the new directory automatically — no CI workflow changes required.

## Test plan

- [x] `pytest tests/` — 104 passed, 1 skipped (Spark Connect)
- [x] `pylint typedspark` — 10/10
- [x] `flake8`, `black --check .`, `isort --check .`, `docformatter --black -c **/*.py`, `bandit typedspark/**/*.py`
- [x] `mypy .` — clean (positive `assert_type` and negative `# type: ignore[code]` cases verified)
- [x] `pyright .` — clean (same verifications)
- [x] `coverage report --fail-under 100` — 100%
- [x] Verified each negative case actually fails type-checking when the `# type: ignore` is removed (both mypy `[unused-ignore]` and pyright `reportUnnecessaryTypeIgnoreComment` fire)
- [x] Verified each positive `assert_type` actually fails when given a wrong expected type (both checkers fire)
- [x] Re-ran full test suite + mypy on Python 3.14

https://claude.ai/code/session_01A9NFSNRGipr1FyejGXbDRr