### PR TITLE
Run docs notebooks in a shared kernel to speed up CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,9 +115,4 @@ jobs:
           coverage report -m --fail-under 100
       - name: Run notebooks
         if: ${{ matrix.pyspark-version == '4.1.1' }}
-        run: |
-          for FILE in docs/*/*.ipynb; do
-            BASE=$(basename $FILE)
-            cp $FILE .
-            jupyter nbconvert --to notebook $BASE --execute
-          done
+        run: python docs/run_notebooks.py docs/*/*.ipynb

--- a/docs/run_notebooks.py
+++ b/docs/run_notebooks.py
@@ -1,10 +1,10 @@
 """Execute notebooks in a single shared Jupyter kernel.
 
-Used by CI to verify the example notebooks. Reusing one kernel means the JVM
-and Spark session start once (on the first ``SparkSession.builder.getOrCreate()``
-call) and are shared across notebooks. ``%reset -f`` between notebooks clears
-the IPython namespace without tearing down the JVM-side Spark session, so each
-notebook still has to create its own imports and ``spark`` handle.
+Used by CI to verify the example notebooks. Reusing one kernel means the JVM and Spark
+session start once (on the first ``SparkSession.builder.getOrCreate()`` call) and are
+shared across notebooks. ``%reset -f`` between notebooks clears the IPython namespace
+without tearing down the JVM-side Spark session, so each notebook still has to create
+its own imports and ``spark`` handle.
 """
 
 from __future__ import annotations

--- a/docs/run_notebooks.py
+++ b/docs/run_notebooks.py
@@ -1,0 +1,46 @@
+"""Execute notebooks in a single shared Jupyter kernel.
+
+Used by CI to verify the example notebooks. Reusing one kernel means the JVM
+and Spark session start once (on the first ``SparkSession.builder.getOrCreate()``
+call) and are shared across notebooks. ``%reset -f`` between notebooks clears
+the IPython namespace without tearing down the JVM-side Spark session, so each
+notebook still has to create its own imports and ``spark`` handle.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import nbformat
+from jupyter_client.manager import KernelManager
+from nbclient import NotebookClient
+from nbclient.exceptions import CellExecutionError
+
+
+def main(paths: list[str]) -> int:
+    if not paths:
+        print("usage: run_notebooks.py <notebook> [<notebook> ...]", file=sys.stderr)
+        return 2
+
+    km = KernelManager()
+    km.start_kernel()
+    failures: list[str] = []
+    try:
+        for path in paths:
+            nb = nbformat.read(path, as_version=4)
+            nb.cells.insert(0, nbformat.v4.new_code_cell("%reset -f"))
+            try:
+                NotebookClient(nb, km=km).execute()
+            except CellExecutionError as exc:
+                failures.append(path)
+                print(f"FAIL: {path}\n{exc}", file=sys.stderr)
+            else:
+                print(f"OK:   {path}")
+    finally:
+        km.shutdown_kernel()
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- The notebook step previously ran `jupyter nbconvert --execute` in a fresh process per notebook, paying JVM + Spark session startup ~18 times per CI build.
- Replace the shell loop with `docs/run_notebooks.py`, a small driver that executes every notebook in one persistent Jupyter kernel. `SparkSession.builder.getOrCreate()` is idempotent within a process, so the JVM only boots on the first notebook and the rest reuse the same session.
- `%reset -f` is prepended to each notebook so IPython namespace isolation is preserved (each notebook still has to do its own imports / `spark` handle); the reset doesn't affect the JVM-side Spark session.

## Test plan
- [ ] CI green on this branch
- [ ] `Run notebooks` step is noticeably faster than on `main`
- [ ] All 18 notebooks still execute successfully (script exits non-zero on any cell failure)

https://claude.ai/code/session_01Vq6auoJueMtTpWSEsvCLwH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vq6auoJueMtTpWSEsvCLwH)_