### PR TITLE
Make str(Column) return the column name

### DIFF
--- a/tests/_core/test_column.py
+++ b/tests/_core/test_column.py
@@ -142,6 +142,11 @@ def test_column_repr_no_spark_session():
         assert repr(A.a) == "Column<'a'>"
 
 
+def test_column_str(spark: SparkSession):
+    assert str(A.a) == "a"
+    assert str(A.b) == "b"
+
+
 class Cause(Schema):
     source: Column[StringType]
 

--- a/typedspark/_core/column.py
+++ b/typedspark/_core/column.py
@@ -146,3 +146,6 @@ class Column(SparkColumn, Generic[T]):
             return f"Column<'{self.str}'> (no active Spark session)"
 
         return super().__repr__()
+
+    def __str__(self) -> str:
+        return self.str


### PR DESCRIPTION
## Summary

- Override `__str__` on typedspark's `Column` so that `str(Schema.name)` returns `"name"` instead of PySpark's `"Column<'name'>"` repr fallback.
- `Schema.name.str` and `repr(Schema.name)` are unchanged.

Closes #837.

## Context

PySpark's `Column` defines `__repr__` (`"Column<'%s'>" % self._jc.toString()`) but no `__str__`, so `str(col)` falls through to the repr. Overriding `__str__` on the typedspark subclass makes the pythonic idiom (`str(Schema.name)`) match the existing `.str` accessor.

## Test plan

- [x] Added `test_column_str` covering `str(A.a) == "a"`.
- [x] Existing `test_column_repr_no_spark_session` still passes (repr behaviour untouched).

https://claude.ai/code/session_0151mKJppWQXdwdPK6asvS5S

---
_Generated by [Claude Code](https://claude.ai/code/session_0151mKJppWQXdwdPK6asvS5S)_